### PR TITLE
Replace preference slider with model floor selector

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -196,12 +196,11 @@ function handleConfig(args) {
       console.log(`  ${k}: ${JSON.stringify(v)}${label}`);
     }
     console.log('\n  Set a value: claude-tokens config <key> <value>');
-    console.log('  Example: claude-tokens config routing_preference 20\n');
-    console.log('  Preference guide:');
-    console.log('    0-25:  Max savings — pushes work to haiku/sonnet aggressively');
-    console.log('    26-50: Cost-conscious (default 35) — sonnet-heavy, opus only for architecture');
-    console.log('    51-75: Balanced — opus for complex tasks');
-    console.log('    76-100: Max quality — opus for anything medium+\n');
+    console.log('  Example: claude-tokens config model_floor haiku\n');
+    console.log('  Model floor (starting model):');
+    console.log('    haiku  — Start everything on haiku, only upgrade when needed');
+    console.log('    sonnet — Start on sonnet (default), upgrade to opus for complex work');
+    console.log('    opus   — Everything runs on opus, no routing\n');
     return;
   }
 
@@ -234,16 +233,32 @@ function handleConfig(args) {
     return;
   }
 
-  // Validate routing_preference range
+  // Validate model_floor
+  if (key === 'model_floor') {
+    const valid = ['haiku', 'sonnet', 'opus'];
+    if (!valid.includes(value)) {
+      console.error(`  Error: model_floor must be one of: ${valid.join(', ')}`);
+      process.exit(1);
+    }
+    config.set('model_floor', value);
+    const labels = { haiku: 'haiku-first (max savings)', sonnet: 'sonnet-first (default)', opus: 'opus-first (no routing)' };
+    console.log(`\n  ✓ model_floor set to ${value} — ${labels[value]}\n`);
+    return;
+  }
+
+  // Legacy: routing_preference — map to model_floor
   if ((key === 'routing_preference' || key === '--preference') && typeof parsed === 'number') {
     if (parsed < 0 || parsed > 100) {
       console.error('  Error: routing_preference must be 0-100');
       process.exit(1);
     }
-    const k = 'routing_preference';
-    config.set(k, parsed);
+    config.set('routing_preference', parsed);
+    // Also set model_floor based on the preference
+    const floor = parsed <= 25 ? 'haiku' : parsed <= 75 ? 'sonnet' : 'opus';
+    config.set('model_floor', floor);
     const label = parsed <= 25 ? 'max savings' : parsed <= 50 ? 'cost-conscious' : parsed <= 75 ? 'balanced' : 'max quality';
-    console.log(`\n  ✓ ${k} set to ${parsed} (${label})\n`);
+    console.log(`\n  ✓ routing_preference set to ${parsed} (${label})`);
+    console.log(`  ✓ model_floor set to ${floor}\n`);
     return;
   }
 

--- a/bin/hook-router.js
+++ b/bin/hook-router.js
@@ -53,11 +53,29 @@ function handleSessionStart(input) {
   return null;
 }
 
+// Correction patterns — user is unhappy with previous turn's result
+const CORRECTION_PATTERNS = /^(no[,. !]|wrong|that's not right|try again|fix (this|that|it)|redo|not what i|that didn't work|still broken|nope|incorrect)/i;
+
 function handleUserPromptSubmit(input) {
   const prompt = input.prompt || '';
 
   // Skip very short prompts (commands, yes/no answers)
   if (prompt.length < 10) return null;
+
+  // ── Correction detection: check if this prompt is correcting the previous turn ──
+  const trimmed = prompt.trim();
+  if (CORRECTION_PATTERNS.test(trimmed)) {
+    const lastDecision = events.getLastRoutingDecision(input.session_id);
+    if (lastDecision) {
+      events.logEvent('outcome_correction', {
+        session_id: input.session_id,
+        project: getProject(input),
+        prior_family: (lastDecision.classification || {}).family || 'unknown',
+        prior_model: lastDecision.recommended_model || 'opus',
+        prompt_preview: trimmed.slice(0, 100),
+      });
+    }
+  }
 
   const classification = router.classifyTask(prompt);
   const recommendation = router.recommendModel(classification);
@@ -288,19 +306,67 @@ function handleSubagentStop(input) {
 }
 
 function handleStop(input) {
+  const lastDecision = events.getLastRoutingDecision(input.session_id);
+
   events.logEvent('turn_end', {
     session_id: input.session_id,
     project: getProject(input),
   });
+
+  // Log a successful outcome for the last routing decision
+  if (lastDecision) {
+    // Check for escalation: was same family dispatched to a higher model?
+    const dispatches = events.getSessionEvents(input.session_id, { type: 'subagent_dispatch' });
+    const decisionTs = lastDecision.ts;
+    const family = (lastDecision.classification || {}).family || 'unknown';
+    const recModel = lastDecision.recommended_model || 'opus';
+    const modelTier = { haiku: 0, sonnet: 1, opus: 2 };
+
+    // Escalation = same family dispatched to a higher-tier model after the routing decision
+    const wasEscalated = dispatches.some(d => {
+      if (!d.ts || d.ts < decisionTs) return false;
+      const dFamily = (d.classification || {}).family || 'unknown';
+      const dModel = d.model_used || 'opus';
+      return dFamily === family && (modelTier[dModel] || 0) > (modelTier[recModel] || 0);
+    });
+
+    events.logEvent('outcome', {
+      session_id: input.session_id,
+      project: getProject(input),
+      family,
+      model: recModel,
+      turn_success: true,
+      was_escalated: wasEscalated,
+    });
+  }
+
   return null;
 }
 
 function handleStopFailure(input) {
+  const lastDecision = events.getLastRoutingDecision(input.session_id);
+
   events.logEvent('error', {
     session_id: input.session_id,
     project: getProject(input),
     error_type: input.error_type,
   });
+
+  // Log a failed outcome for the last routing decision
+  if (lastDecision) {
+    const family = (lastDecision.classification || {}).family || 'unknown';
+    const recModel = lastDecision.recommended_model || 'opus';
+
+    events.logEvent('outcome', {
+      session_id: input.session_id,
+      project: getProject(input),
+      family,
+      model: recModel,
+      turn_success: false,
+      was_escalated: false,
+    });
+  }
+
   return null;
 }
 

--- a/bin/hook-router.js
+++ b/bin/hook-router.js
@@ -86,8 +86,10 @@ function handleUserPromptSubmit(input) {
     prompt_preview: prompt.slice(0, 200),
     classification,
     recommended_model: recommendation.model,
+    base_model: recommendation.baseModel,
+    model_floor: recommendation.model_floor,
     recommended_reason: recommendation.reasons.join('; '),
-    actual_model: null, // filled by PreToolUse or Stop
+    actual_model: null,
     was_delegated: null,
   });
 

--- a/public/index.html
+++ b/public/index.html
@@ -658,21 +658,37 @@ function renderFloorWarning(D) {
   const total = opusCalls + sonnetCalls + haikuCalls;
   if (total === 0) return '';
 
-  const opusPct = Math.round(opusCalls / total * 100);
-  const opusCost = bm.opus?.cost || 0;
-  const otherCost = (bm.sonnet?.cost || 0) + (bm.haiku?.cost || 0);
+  // Detect primary session model — the one with the most calls
+  const byCount = [['opus', opusCalls], ['sonnet', sonnetCalls], ['haiku', haikuCalls]];
+  const primaryModel = byCount.sort((a, b) => b[1] - a[1])[0][0];
+  const primaryCalls = byCount[0][1];
+  const primaryPct = Math.round(primaryCalls / total * 100);
+  const primaryCost = bm[primaryModel]?.cost || 0;
+  const totalCost = (bm.opus?.cost || 0) + (bm.sonnet?.cost || 0) + (bm.haiku?.cost || 0);
 
-  // Show warning if floor is not opus but opus dominates usage
-  if (floor !== 'opus' && opusPct > 70) {
-    const floorLabel = floor === 'sonnet' ? 'sonnet' : 'haiku';
+  const tierOrder = { haiku: 0, sonnet: 1, opus: 2 };
+  const sessionMoreExpensive = tierOrder[primaryModel] > tierOrder[floor];
+
+  if (sessionMoreExpensive) {
+    // Mismatch: session model is more expensive than floor setting
     return `<div class="floor-warn">
-      <strong>${opusPct}% of your API calls are still running on opus</strong> ($${opusCost.toFixed(2)} of $${(opusCost + otherCost).toFixed(2)} today).
-      The model floor only affects subagent routing — your main session is running on opus.
-      To actually run on ${floorLabel}, start Claude Code with <code>claude --model ${floorLabel}</code>.
-      Token Coach will still upgrade to opus when a task needs it.
+      <div style="margin-bottom:6px"><strong>Your Claude Code session is running on: ${primaryModel}</strong> &mdash; ${primaryPct}% of API calls, $${primaryCost.toFixed(2)} today</div>
+      <div style="margin-bottom:6px">The model floor only controls subagent routing. Your main session won't change until you restart Claude Code with a different model.</div>
+      <div>To match your floor, run: <code>claude --model ${floor}</code> &mdash; Token Coach will still upgrade to opus when a task genuinely needs it.</div>
     </div>`;
   }
-  return '';
+
+  // Session model matches or is cheaper than floor — green confirmation
+  if (primaryModel === floor) {
+    return `<div class="floor-warn" style="border-left-color:#16a34a;background:rgba(22,163,74,0.06)">
+      <strong style="color:#16a34a">&#10003; Your session is running on ${primaryModel}</strong> &mdash; matches your floor setting. Token Coach will upgrade to more capable models when tasks need it.
+    </div>`;
+  }
+
+  // Session is cheaper than floor (e.g. session=haiku, floor=sonnet) — informational
+  return `<div class="floor-warn" style="border-left-color:var(--dim);background:transparent">
+    <strong>Your Claude Code session is running on: ${primaryModel}</strong> (${primaryPct}% of calls, $${primaryCost.toFixed(2)} today). Token Coach will recommend up to ${floor} for subagent tasks.
+  </div>`;
 }
 
 function renderFloorSelector(current) {

--- a/public/index.html
+++ b/public/index.html
@@ -650,45 +650,8 @@ function renderSavings(savings) {
 }
 
 function renderFloorWarning(D) {
-  const floor = D.config?.model_floor || 'sonnet';
-  const bm = D.todayTokenUsage?.byModel || {};
-  const opusCalls = bm.opus?.calls || 0;
-  const sonnetCalls = bm.sonnet?.calls || 0;
-  const haikuCalls = bm.haiku?.calls || 0;
-  const total = opusCalls + sonnetCalls + haikuCalls;
-  if (total === 0) return '';
-
-  // Detect primary session model — the one with the most calls
-  const byCount = [['opus', opusCalls], ['sonnet', sonnetCalls], ['haiku', haikuCalls]];
-  const primaryModel = byCount.sort((a, b) => b[1] - a[1])[0][0];
-  const primaryCalls = byCount[0][1];
-  const primaryPct = Math.round(primaryCalls / total * 100);
-  const primaryCost = bm[primaryModel]?.cost || 0;
-  const totalCost = (bm.opus?.cost || 0) + (bm.sonnet?.cost || 0) + (bm.haiku?.cost || 0);
-
-  const tierOrder = { haiku: 0, sonnet: 1, opus: 2 };
-  const sessionMoreExpensive = tierOrder[primaryModel] > tierOrder[floor];
-
-  if (sessionMoreExpensive) {
-    // Mismatch: session model is more expensive than floor setting
-    return `<div class="floor-warn">
-      <div style="margin-bottom:6px"><strong>Your Claude Code session is running on: ${primaryModel}</strong> &mdash; ${primaryPct}% of API calls, $${primaryCost.toFixed(2)} today</div>
-      <div style="margin-bottom:6px">The model floor only controls subagent routing. Your main session won't change until you restart Claude Code with a different model.</div>
-      <div>To match your floor, run: <code>claude --model ${floor}</code> &mdash; Token Coach will still upgrade to opus when a task genuinely needs it.</div>
-    </div>`;
-  }
-
-  // Session model matches or is cheaper than floor — green confirmation
-  if (primaryModel === floor) {
-    return `<div class="floor-warn" style="border-left-color:#16a34a;background:rgba(22,163,74,0.06)">
-      <strong style="color:#16a34a">&#10003; Your session is running on ${primaryModel}</strong> &mdash; matches your floor setting. Token Coach will upgrade to more capable models when tasks need it.
-    </div>`;
-  }
-
-  // Session is cheaper than floor (e.g. session=haiku, floor=sonnet) — informational
-  return `<div class="floor-warn" style="border-left-color:var(--dim);background:transparent">
-    <strong>Your Claude Code session is running on: ${primaryModel}</strong> (${primaryPct}% of calls, $${primaryCost.toFixed(2)} today). Token Coach will recommend up to ${floor} for subagent tasks.
-  </div>`;
+  // Session model display removed — Claude Code's /config model selector doesn't reliably persist
+  return '';
 }
 
 function renderFloorSelector(current) {

--- a/public/index.html
+++ b/public/index.html
@@ -209,16 +209,40 @@
   .deleg-arrow { color: var(--dim); font-size: 11px; margin: 0 2px; }
 
   /* ─── Insights ───────────────────────────── */
-  .ins-item { padding: 10px 0; border-bottom: 1px solid var(--separator); }
-  .ins-item:last-child { border-bottom: none; }
-  .ins-title { font-size: 13px; font-weight: 600; color: var(--fg); margin-bottom: 2px; display: flex; align-items: center; gap: 6px; }
-  .ins-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+  .ins-item {
+    padding: 10px 12px; margin-bottom: 8px; border-radius: 6px;
+    border-left: 3px solid var(--border); background: transparent;
+  }
+  .ins-item:last-child { margin-bottom: 0; }
+  .ins-item-crit {
+    border-left-color: var(--danger); background: var(--danger-dim);
+  }
+  .ins-item-warn {
+    border-left-color: var(--accent); background: var(--accent-dim);
+  }
+  .ins-item-ok {
+    border-left-color: #16a34a; background: rgba(22, 163, 74, 0.06);
+  }
+  [data-theme="dark"] .ins-item-ok { background: rgba(22, 163, 74, 0.08); }
+  .ins-item-info {
+    border-left-color: var(--dim); background: transparent;
+  }
+  .ins-title { font-size: 13px; font-weight: 600; color: var(--fg); margin-bottom: 3px; display: flex; align-items: center; gap: 6px; }
+  .ins-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
   .ins-dot-crit { background: var(--danger); }
   .ins-dot-warn { background: var(--accent); }
   .ins-dot-info { background: var(--dim); }
   .ins-dot-ok { background: #16a34a; }
-  .ins-detail { font-size: 12px; color: var(--muted); line-height: 1.5; margin-bottom: 4px; }
-  .ins-action { font-size: 12px; color: var(--accent); }
+  .ins-detail { font-size: 12px; color: var(--muted); line-height: 1.5; margin-bottom: 6px; }
+  .ins-action {
+    display: inline-block; font-size: 11px; font-weight: 500;
+    color: var(--accent); background: var(--accent-dim);
+    padding: 3px 10px; border-radius: 4px;
+    line-height: 1.4;
+  }
+  .ins-item-crit .ins-action {
+    color: var(--danger); background: var(--danger-dim);
+  }
 
   /* ─── Hour grid ──────────────────────────── */
   .hr-grid { display: grid; grid-template-columns: repeat(24, 1fr); gap: 2px; }
@@ -676,10 +700,11 @@ function renderInsights(insights) {
   let html = '';
   for (const i of live) {
     const dot = i.severity === 'critical' ? 'crit' : i.severity === 'warning' ? 'warn' : i.severity === 'success' ? 'ok' : 'info';
-    html += `<div class="ins-item">
+    const card = i.severity === 'critical' ? 'crit' : i.severity === 'warning' ? 'warn' : i.severity === 'success' ? 'ok' : 'info';
+    html += `<div class="ins-item ins-item-${card}">
       <div class="ins-title"><span class="ins-dot ins-dot-${dot}"></span>${esc(i.title)}</div>
       <div class="ins-detail">${esc(i.detail)}</div>
-      <div class="ins-action">&rarr; ${esc(i.action)}</div>
+      <div class="ins-action">${esc(i.action)}</div>
     </div>`;
   }
   if (hist.length) {
@@ -687,10 +712,10 @@ function renderInsights(insights) {
       <button onclick="this.nextElementSibling.style.display=this.nextElementSibling.style.display==='none'?'block':'none'" style="font-size:11px;color:var(--dim);background:none;border:1px solid var(--border);border-radius:4px;padding:3px 8px;cursor:pointer;font-family:inherit">${hist.length} historical</button>
       <div style="display:none">`;
     for (const i of hist) {
-      html += `<div class="ins-item" style="opacity:0.6">
+      html += `<div class="ins-item ins-item-info" style="opacity:0.6">
         <div class="ins-title"><span class="ins-dot ins-dot-info"></span>${esc(i.title)}</div>
         <div class="ins-detail">${esc(i.detail)}</div>
-        <div class="ins-action">&rarr; ${esc(i.action)}</div>
+        <div class="ins-action">${esc(i.action)}</div>
       </div>`;
     }
     html += '</div></div>';

--- a/public/index.html
+++ b/public/index.html
@@ -454,7 +454,7 @@ function buildHTML() {
     <div class="g2 anim d2" style="height:560px">
       <div class="card" style="display:flex;flex-direction:column;min-height:0">
         <div class="card-hd">
-          <h2>Routing timeline</h2>
+          <h2>Routing decisions</h2>
           <span class="ct" id="v-total">${r.totalTasks} total</span>
         </div>
         <div id="v-rd-strip" style="display:flex;gap:8px 14px;flex-wrap:wrap;margin-bottom:10px;font-size:11px;color:var(--dim)">${renderRoutingStrip(D.routingEvents)}</div>
@@ -672,17 +672,24 @@ function renderTimeline(tab) {
     const baseTier = baseModel ? (tier[baseModel] ?? 1) : finalTier;
 
     if (t.isSubagent) {
+      // Subagent: opus delegated this to a cheaper model
       badge = '<span class="tl-badge tl-badge-down">subagent</span>';
-      const saved = (promptCost[baseModel] || 0) - (promptCost[finalModel] || 0);
-      if (saved > 0) savings = `<span class="tl-saved">saved ~$${saved.toFixed(2)}</span>`;
+      const saved = (promptCost[baseModel] || promptCost.opus) - (promptCost[finalModel] || 0);
+      if (saved > 0) savings = `<span class="tl-saved">~$${saved.toFixed(2)} saved</span>`;
     } else if (baseModel && baseTier > finalTier) {
-      badge = `<span class="tl-badge tl-badge-down">↓ saved from ${baseModel}</span>`;
+      // Router downgraded: base was more expensive than final
+      badge = `<span class="tl-badge tl-badge-down">↓ routed from ${baseModel}</span>`;
       const saved = (promptCost[baseModel] || 0) - (promptCost[finalModel] || 0);
       if (saved > 0) savings = `<span class="tl-saved">~$${saved.toFixed(2)} saved</span>`;
     } else if (baseModel && baseTier < finalTier) {
+      // Router upgraded: task needed more capability
       badge = `<span class="tl-badge tl-badge-up">↑ upgraded from ${baseModel}</span>`;
+    } else if (baseModel && baseTier === finalTier) {
+      // Base matched final — no change needed
+      badge = `<span class="tl-badge tl-badge-stay">no change</span>`;
     } else {
-      badge = '<span class="tl-badge tl-badge-stay">stayed at floor</span>';
+      // No baseModel data (older events) — just show the recommendation
+      badge = `<span class="tl-badge tl-badge-stay">recommended</span>`;
     }
 
     return `<div class="tl-row">
@@ -765,14 +772,17 @@ function renderTokenHogs(hogs) {
 function renderRoutingStrip(re) {
   if (!re?.stats) return '';
   const s = re.stats, rec = s.byRecommended || {};
-  // Estimate savings: count how many tasks were downgraded from opus
-  const downgraded = (rec.haiku || 0) + (rec.sonnet || 0);
-  const savedEst = downgraded > 0 ? (downgraded * 0.07).toFixed(2) : '0.00'; // ~$0.07 avg savings per downgrade
-  return `<span><strong style="font-family:var(--mono)">${s.total||0}</strong> tasks routed</span>
-    <span><strong style="font-family:var(--mono)">${rec.opus||0}</strong> on opus</span>
-    <span><strong style="font-family:var(--mono)">${rec.sonnet||0}</strong> on sonnet</span>
-    <span><strong style="font-family:var(--mono)">${rec.haiku||0}</strong> on haiku</span>
-    <span style="color:#16a34a;font-weight:600">~$${savedEst} estimated savings</span>`;
+  const bm = DATA?.todayTokenUsage?.byModel || {};
+  const actualOpus = bm.opus?.calls || 0;
+  const actualSonnet = bm.sonnet?.calls || 0;
+  const actualHaiku = bm.haiku?.calls || 0;
+  const routed = (rec.sonnet || 0) + (rec.haiku || 0);
+  return `<span style="font-weight:600;color:var(--muted)">Actual API calls:</span>
+    <span><strong style="font-family:var(--mono)">${actualOpus}</strong> opus</span>
+    <span><strong style="font-family:var(--mono)">${actualSonnet}</strong> sonnet</span>
+    <span><strong style="font-family:var(--mono)">${actualHaiku}</strong> haiku</span>
+    <span style="color:var(--dim)">&middot;</span>
+    <span><strong style="font-family:var(--mono)">${routed}</strong> routed to cheaper models</span>`;
 }
 
 function renderProjectFilters(sc) {

--- a/public/index.html
+++ b/public/index.html
@@ -147,6 +147,31 @@
   @media (max-width: 860px) { .g2 { grid-template-columns: 1fr; height: auto !important; } }
   @media (max-width: 640px) { .g2-eq { grid-template-columns: 1fr; } }
 
+  /* ─── Savings card ───────────────────────── */
+  .savings-hero {
+    display: flex; gap: 24px; align-items: baseline; margin-bottom: 16px;
+    flex-wrap: wrap;
+  }
+  .savings-big {
+    font-family: var(--mono); font-size: 28px; font-weight: 700;
+    color: #16a34a; font-variant-numeric: tabular-nums; letter-spacing: -0.02em;
+  }
+  [data-theme="dark"] .savings-big { color: #4ade80; }
+  .savings-sub { font-size: 12px; color: var(--dim); }
+  .savings-sub strong { color: var(--muted); font-weight: 600; }
+  .savings-chart { width: 100%; height: 120px; }
+  .savings-legend {
+    display: flex; gap: 16px; margin-top: 8px; font-size: 11px; color: var(--dim);
+  }
+  .savings-legend span::before {
+    content: ''; display: inline-block; width: 10px; height: 3px;
+    border-radius: 2px; margin-right: 4px; vertical-align: 2px;
+  }
+  .savings-legend .leg-actual::before { background: var(--accent); }
+  .savings-legend .leg-counter::before { background: var(--dim); opacity: 0.4; }
+  .savings-legend .leg-saved::before { background: #16a34a; opacity: 0.3; }
+  [data-theme="dark"] .savings-legend .leg-saved::before { background: #4ade80; }
+
   /* ─── Model floor selector ────────────────── */
   .floor-row {
     display: flex; gap: 8px; align-items: stretch;
@@ -410,6 +435,14 @@ function buildHTML() {
 
     <div class="card anim d1" style="margin-bottom:12px">
       <div class="card-hd">
+        <h2>Did routing pay for itself?</h2>
+        <span class="ct" id="v-savings-pct">${D.savings?.today?.savingsPercent > 0 ? Math.round(D.savings.today.savingsPercent) + '% saved' : 'no savings yet'}</span>
+      </div>
+      <div id="v-savings-body">${renderSavings(D.savings)}</div>
+    </div>
+
+    <div class="card anim d1" style="margin-bottom:12px">
+      <div class="card-hd">
         <h2>Model floor</h2>
         <span class="ct" id="v-floor-label">${D.config?.model_floor || 'sonnet'}</span>
       </div>
@@ -509,6 +542,84 @@ function render() {
 }
 
 /* ─── Renderers ─────────────────────────────── */
+
+function renderSavings(savings) {
+  if (!savings) return '<div class="empty">No savings data yet.</div>';
+  const t = savings.today || {};
+  const daily = savings.daily || [];
+
+  // Cumulative savings
+  const cumSavings = daily.reduce((sum, d) => sum + (d.savings || 0), 0) + (t.savings || 0);
+  const todaySavings = t.savings || 0;
+
+  let html = `<div class="savings-hero">
+    <div>
+      <div class="savings-big">$${cumSavings.toFixed(2)}</div>
+      <div class="savings-sub">total saved vs all-opus</div>
+    </div>
+    <div>
+      <div class="savings-sub"><strong>$${todaySavings.toFixed(2)}</strong> saved today</div>
+      <div class="savings-sub"><strong>$${(t.actual || 0).toFixed(2)}</strong> actual &middot; <strong>$${(t.counterfactual || 0).toFixed(2)}</strong> if all opus</div>
+    </div>
+  </div>`;
+
+  // Build SVG chart — last 14 days + today
+  const chartData = [...daily];
+  const todayStr = new Date().toISOString().slice(0, 10);
+  // Add today if not already in daily
+  if (!chartData.length || chartData[chartData.length - 1].date !== todayStr) {
+    chartData.push({ date: todayStr, actual: Math.round((t.actual || 0) * 100) / 100, counterfactual: Math.round((t.counterfactual || 0) * 100) / 100, savings: Math.round(todaySavings * 100) / 100 });
+  }
+
+  if (chartData.length < 2) {
+    html += '<div class="savings-sub" style="margin-top:8px">Need at least 2 days of data for the chart.</div>';
+    return html;
+  }
+
+  const W = 600, H = 120, PAD = 28;
+  const maxVal = Math.max(...chartData.map(d => Math.max(d.actual, d.counterfactual)), 1);
+  const xStep = (W - PAD * 2) / (chartData.length - 1);
+
+  function y(val) { return H - PAD - ((val / maxVal) * (H - PAD * 2)); }
+
+  const actualPoints = chartData.map((d, i) => `${PAD + i * xStep},${y(d.actual)}`);
+  const counterPoints = chartData.map((d, i) => `${PAD + i * xStep},${y(d.counterfactual)}`);
+
+  // Shaded savings area (between the two lines)
+  const areaPath = `M${counterPoints[0]} ${counterPoints.map(p => `L${p}`).join(' ')} L${PAD + (chartData.length - 1) * xStep},${y(chartData[chartData.length - 1].actual)} ${[...actualPoints].reverse().map(p => `L${p}`).join(' ')} Z`;
+
+  // X-axis labels (show every few days)
+  const labelInterval = chartData.length <= 7 ? 1 : chartData.length <= 14 ? 2 : 3;
+  const xLabels = chartData.map((d, i) => {
+    if (i % labelInterval !== 0 && i !== chartData.length - 1) return '';
+    const label = d.date.slice(5); // MM-DD
+    return `<text x="${PAD + i * xStep}" y="${H - 4}" text-anchor="middle" fill="currentColor" opacity="0.4" font-size="9" font-family="var(--mono)">${label}</text>`;
+  }).join('');
+
+  // Y-axis: just max value
+  const yLabel = `<text x="${PAD - 4}" y="${PAD}" text-anchor="end" fill="currentColor" opacity="0.4" font-size="9" font-family="var(--mono)">$${maxVal.toFixed(0)}</text>`;
+
+  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+  const savedFill = isDark ? 'rgba(74, 222, 128, 0.12)' : 'rgba(22, 163, 74, 0.1)';
+  const accentStroke = isDark ? '#d4a843' : '#6d5000';
+  const dimStroke = isDark ? 'rgba(163,163,163,0.3)' : 'rgba(82,82,82,0.25)';
+
+  html += `<svg class="savings-chart" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" role="img" aria-label="Savings chart: actual vs counterfactual cost over ${chartData.length} days">
+    <path d="${areaPath}" fill="${savedFill}" />
+    <polyline points="${counterPoints.join(' ')}" fill="none" stroke="${dimStroke}" stroke-width="1.5" stroke-dasharray="4,3" />
+    <polyline points="${actualPoints.join(' ')}" fill="none" stroke="${accentStroke}" stroke-width="2" />
+    ${xLabels}
+    ${yLabel}
+  </svg>`;
+
+  html += `<div class="savings-legend">
+    <span class="leg-actual">actual spend</span>
+    <span class="leg-counter">if all opus</span>
+    <span class="leg-saved">savings</span>
+  </div>`;
+
+  return html;
+}
 
 function renderFloorSelector(current) {
   const floors = [

--- a/public/index.html
+++ b/public/index.html
@@ -147,6 +147,27 @@
   @media (max-width: 860px) { .g2 { grid-template-columns: 1fr; height: auto !important; } }
   @media (max-width: 640px) { .g2-eq { grid-template-columns: 1fr; } }
 
+  /* ─── Model floor selector ────────────────── */
+  .floor-row {
+    display: flex; gap: 8px; align-items: stretch;
+  }
+  .floor-btn {
+    flex: 1; padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius);
+    background: var(--card); cursor: pointer; text-align: left; font-family: inherit;
+    transition: border-color 200ms, background 200ms;
+  }
+  .floor-btn:hover { border-color: var(--dim); }
+  .floor-btn.on {
+    border-color: var(--accent); background: var(--accent-dim);
+  }
+  .floor-btn strong {
+    display: block; font-size: 13px; font-weight: 600; margin-bottom: 2px;
+  }
+  .floor-btn span {
+    font-size: 11px; color: var(--dim); line-height: 1.4;
+  }
+  @media (max-width: 640px) { .floor-row { flex-direction: column; } }
+
   /* ─── Model labels ───────────────────────── */
   .ml { font-family: var(--mono); font-size: 11px; font-variant-numeric: tabular-nums; letter-spacing: 0.02em; }
   .ml-opus { font-weight: 700; color: var(--tier-high); }
@@ -258,11 +279,12 @@ function setSection(id, html) {
 function softRefresh() {
   const D = DATA; if (!D) return;
   const s = D.stats, r = D.routing, today = r.todayStats, tab = getEffectiveTab();
-  setText('v-tasks', today.totalTasks);
-  setText('v-opus', today.models.opus || 0);
-  setText('v-sonnet', today.models.sonnet || 0);
-  setText('v-haiku', today.models.haiku || 0);
-  setText('v-deleg', today.delegations);
+  const bm = D.todayTokenUsage?.byModel || {};
+  setText('v-calls', (bm.opus?.calls||0) + (bm.sonnet?.calls||0) + (bm.haiku?.calls||0) + (bm.unknown?.calls||0));
+  setText('v-opus', bm.opus?.calls || 0);
+  setText('v-sonnet', bm.sonnet?.calls || 0);
+  setText('v-haiku', bm.haiku?.calls || 0);
+  setText('v-sessions', Object.keys(D.todayTokenUsage?.bySession || D.sessionCosts?.sessions || {}).length);
   const todayCost = D.todayTokenUsage ? D.todayTokenUsage.totalCost : (D.sessionCosts ? Object.values(D.sessionCosts.sessions||{}).reduce((a,s)=>a+s.estimatedCost,0) : 0);
   setText('v-cost', '$' + todayCost.toFixed(2));
   setText('v-total', r.totalTasks + ' total');
@@ -307,6 +329,15 @@ function buildHTML() {
   const D = DATA; if (!D) return '';
   const s = D.stats, r = D.routing, today = r.todayStats, tab = getEffectiveTab(), isDark = getTheme() === 'dark';
   const totalCost = D.todayTokenUsage ? D.todayTokenUsage.totalCost : Object.values(D.sessionCosts?.sessions||{}).reduce((a,s)=>a+s.estimatedCost,0);
+  // Actual model usage from session JSONL files (what really ran)
+  const bm = D.todayTokenUsage?.byModel || {};
+  const tu = {
+    opusCalls: (bm.opus?.calls||0),
+    sonnetCalls: (bm.sonnet?.calls||0),
+    haikuCalls: (bm.haiku?.calls||0),
+    totalCalls: (bm.opus?.calls||0) + (bm.sonnet?.calls||0) + (bm.haiku?.calls||0) + (bm.unknown?.calls||0),
+    sessionCount: Object.keys(D.todayTokenUsage?.bySession || D.sessionCosts?.sessions || {}).length,
+  };
 
   return `
     <header class="hdr anim" role="banner">
@@ -319,15 +350,25 @@ function buildHTML() {
 
     <main id="main-content">
     <section class="metrics anim d1" aria-label="Today's metrics">
-      <div class="metric"><span class="metric-val" id="v-tasks">${today.totalTasks}</span><span class="metric-label">tasks today</span></div>
-      <div class="metric"><span class="metric-val" id="v-opus">${today.models.opus||0}</span><span class="metric-label">opus</span></div>
-      <div class="metric"><span class="metric-val" id="v-sonnet">${today.models.sonnet||0}</span><span class="metric-label">sonnet</span></div>
-      <div class="metric"><span class="metric-val" id="v-haiku">${today.models.haiku||0}</span><span class="metric-label">haiku</span></div>
-      <div class="metric"><span class="metric-val" id="v-deleg">${today.delegations}</span><span class="metric-label">delegated</span></div>
+      <div class="metric"><span class="metric-val" id="v-calls">${tu.totalCalls||0}</span><span class="metric-label">API calls today</span></div>
+      <div class="metric"><span class="metric-val" id="v-opus">${tu.opusCalls||0}</span><span class="metric-label">opus calls</span></div>
+      <div class="metric"><span class="metric-val" id="v-sonnet">${tu.sonnetCalls||0}</span><span class="metric-label">sonnet calls</span></div>
+      <div class="metric"><span class="metric-val" id="v-haiku">${tu.haikuCalls||0}</span><span class="metric-label">haiku calls</span></div>
+      <div class="metric"><span class="metric-val" id="v-sessions">${tu.sessionCount||0}</span><span class="metric-label">sessions</span></div>
       <div class="metric metric-accent"><span class="metric-val" id="v-cost">$${totalCost.toFixed(2)}</span><span class="metric-label">cost today</span></div>
     </div>
 
     </section>
+
+    <div class="card anim d1" style="margin-bottom:12px">
+      <div class="card-hd">
+        <h2>Model floor</h2>
+        <span class="ct" id="v-floor-label">${D.config?.model_floor || 'sonnet'}</span>
+      </div>
+      <div class="floor-row" id="v-floor-row">
+        ${renderFloorSelector(D.config?.model_floor || 'sonnet')}
+      </div>
+    </div>
 
     <div class="g2 anim d2" style="height:560px">
       <div class="card" style="display:flex;flex-direction:column;min-height:0">
@@ -419,6 +460,32 @@ function render() {
 }
 
 /* ─── Renderers ─────────────────────────────── */
+
+function renderFloorSelector(current) {
+  const floors = [
+    { id: 'haiku', label: 'Haiku-first', desc: 'Start on haiku, only upgrade when needed' },
+    { id: 'sonnet', label: 'Sonnet-first', desc: 'Start on sonnet, upgrade to opus for complex work' },
+    { id: 'opus', label: 'Opus-first', desc: 'Everything runs on opus, no routing' },
+  ];
+  return floors.map(f =>
+    `<button class="floor-btn ${f.id === current ? 'on' : ''}" onclick="setFloor('${f.id}')" aria-pressed="${f.id === current}"><strong>${f.label}</strong><span>${f.desc}</span></button>`
+  ).join('');
+}
+
+function setFloor(floor) {
+  fetch('/api/config', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model_floor: floor }),
+  }).then(r => r.json()).then(cfg => {
+    if (DATA) DATA.config = cfg;
+    // Update UI without full re-render
+    const row = document.getElementById('v-floor-row');
+    if (row) row.innerHTML = renderFloorSelector(floor);
+    const label = document.getElementById('v-floor-label');
+    if (label) label.textContent = floor;
+  }).catch(() => {});
+}
 
 function renderTimeline(tab) {
   if (!DATA) return '';
@@ -517,7 +584,8 @@ function renderTokenHogs(hogs) {
 function renderRoutingStrip(re) {
   if (!re?.stats) return '';
   const s = re.stats, rec = s.byRecommended || {};
-  return `<span><strong style="font-family:var(--mono)">${s.total||0}</strong> classified</span>
+  return `<span style="font-weight:600;color:var(--muted)">Router recommendations:</span>
+    <span><strong style="font-family:var(--mono)">${s.total||0}</strong> classified</span>
     <span><strong style="font-family:var(--mono)">${rec.haiku||0}</strong> haiku</span>
     <span><strong style="font-family:var(--mono)">${rec.sonnet||0}</strong> sonnet</span>
     <span><strong style="font-family:var(--mono)">${rec.opus||0}</strong> opus</span>
@@ -550,7 +618,7 @@ function renderSessionCosts(sc) {
       </div>
       <div style="text-align:right">
         <div style="font-family:var(--mono);font-size:13px;font-weight:600;font-variant-numeric:tabular-nums">$${s.estimatedCost.toFixed(2)}</div>
-        <div style="font-size:11px;color:var(--dim)">${s.prompts} prompts &middot; ${time}</div>
+        <div style="font-size:11px;color:var(--dim)">${s.prompts} API calls &middot; ${time}</div>
       </div>
     </div>`;
   }

--- a/public/index.html
+++ b/public/index.html
@@ -206,7 +206,7 @@
   .tl-meta { display: flex; gap: 8px; margin-top: 2px; align-items: center; }
   .tl-proj { font-size: 11px; color: var(--dim); font-weight: 500; }
   .tl-sz { font-family: var(--mono); font-size: 10px; color: var(--dim); }
-  .deleg-arrow { color: var(--dim); font-size: 11px; margin: 0 2px; }
+  .deleg-hint { color: var(--dim); font-size: 10px; margin-left: 4px; font-weight: 400; font-family: inherit; }
 
   /* ─── Insights ───────────────────────────── */
   .ins-item {
@@ -523,8 +523,8 @@ function renderTimeline(tab) {
     const time = t.timestamp.slice(11, 16);
     let ml;
     if (isDel) {
-      const [src, tgt] = t.model.split('>');
-      ml = modelLabel(src) + '<span class="deleg-arrow">&rarr;</span>' + modelLabel(tgt);
+      const [, tgt] = t.model.split('>');
+      ml = modelLabel(tgt) + '<span class="deleg-hint">subagent</span>';
     } else {
       ml = modelLabel(t.model);
     }
@@ -613,8 +613,8 @@ function renderRoutingStrip(re) {
     <span><strong style="font-family:var(--mono)">${rec.haiku||0}</strong> haiku</span>
     <span><strong style="font-family:var(--mono)">${rec.sonnet||0}</strong> sonnet</span>
     <span><strong style="font-family:var(--mono)">${rec.opus||0}</strong> opus</span>
-    <span><strong style="font-family:var(--mono)">${s.delegated||0}</strong> dispatched</span>
-    <span><strong style="font-family:var(--mono)">${s.delegationRate||0}%</strong> delegation</span>`;
+    <span><strong style="font-family:var(--mono)">${s.delegated||0}</strong> sent to subagents</span>
+    <span><strong style="font-family:var(--mono)">${s.delegationRate||0}%</strong> routed cheaper</span>`;
 }
 
 function renderSessionCosts(sc) {

--- a/public/index.html
+++ b/public/index.html
@@ -203,6 +203,21 @@
     padding: 2px 6px; border-radius: 3px;
   }
 
+  /* ─── Dark mode AAA contrast overrides (floor section) ── */
+  /* .floor-btn.on tints the card bg with accent-dim (~#161512); #a0a0a0 drops
+     to ~6.85:1 on that surface — below the 7:1 AAA threshold. Bump to #b2b2b2
+     which clears 7:1 on both the tinted active state and the plain card bg. */
+  [data-theme="dark"] .floor-btn.on span {
+    color: #b2b2b2;
+  }
+  /* .floor-warn code sits on var(--faint)=#262626. The inherited var(--muted)
+     (#a3a3a3) only achieves ~5.1:1 on that surface — fails AAA. Use a lighter
+     neutral that clears 7:1 on #262626 (needs ≥ #ababab; use #d0d0d0 for
+     comfortable margin). */
+  [data-theme="dark"] .floor-warn code {
+    color: #d0d0d0;
+  }
+
   /* ─── Model labels ───────────────────────── */
   .ml { font-family: var(--mono); font-size: 11px; font-variant-numeric: tabular-nums; letter-spacing: 0.02em; }
   .ml-opus { font-weight: 700; color: var(--tier-high); }

--- a/public/index.html
+++ b/public/index.html
@@ -192,6 +192,16 @@
     font-size: 11px; color: var(--dim); line-height: 1.4;
   }
   @media (max-width: 640px) { .floor-row { flex-direction: column; } }
+  .floor-warn {
+    margin-top: 10px; padding: 10px 12px; border-radius: 6px;
+    border-left: 3px solid var(--accent); background: var(--accent-dim);
+    font-size: 12px; color: var(--muted); line-height: 1.5;
+  }
+  .floor-warn strong { color: var(--fg); }
+  .floor-warn code {
+    font-family: var(--mono); font-size: 11px; background: var(--faint);
+    padding: 2px 6px; border-radius: 3px;
+  }
 
   /* ─── Model labels ───────────────────────── */
   .ml { font-family: var(--mono); font-size: 11px; font-variant-numeric: tabular-nums; letter-spacing: 0.02em; }
@@ -446,9 +456,11 @@ function buildHTML() {
         <h2>Model floor</h2>
         <span class="ct" id="v-floor-label">${D.config?.model_floor || 'sonnet'}</span>
       </div>
+      <div style="font-size:12px;color:var(--dim);margin-bottom:10px;line-height:1.5">The model floor controls which model Token Coach recommends for subagent tasks. Your main session model is set when you start Claude Code.</div>
       <div class="floor-row" id="v-floor-row">
         ${renderFloorSelector(D.config?.model_floor || 'sonnet')}
       </div>
+      <div id="v-floor-warning">${renderFloorWarning(D)}</div>
     </div>
 
     <div class="g2 anim d2" style="height:560px">
@@ -620,6 +632,32 @@ function renderSavings(savings) {
   </div>`;
 
   return html;
+}
+
+function renderFloorWarning(D) {
+  const floor = D.config?.model_floor || 'sonnet';
+  const bm = D.todayTokenUsage?.byModel || {};
+  const opusCalls = bm.opus?.calls || 0;
+  const sonnetCalls = bm.sonnet?.calls || 0;
+  const haikuCalls = bm.haiku?.calls || 0;
+  const total = opusCalls + sonnetCalls + haikuCalls;
+  if (total === 0) return '';
+
+  const opusPct = Math.round(opusCalls / total * 100);
+  const opusCost = bm.opus?.cost || 0;
+  const otherCost = (bm.sonnet?.cost || 0) + (bm.haiku?.cost || 0);
+
+  // Show warning if floor is not opus but opus dominates usage
+  if (floor !== 'opus' && opusPct > 70) {
+    const floorLabel = floor === 'sonnet' ? 'sonnet' : 'haiku';
+    return `<div class="floor-warn">
+      <strong>${opusPct}% of your API calls are still running on opus</strong> ($${opusCost.toFixed(2)} of $${(opusCost + otherCost).toFixed(2)} today).
+      The model floor only affects subagent routing — your main session is running on opus.
+      To actually run on ${floorLabel}, start Claude Code with <code>claude --model ${floorLabel}</code>.
+      Token Coach will still upgrade to opus when a task needs it.
+    </div>`;
+  }
+  return '';
 }
 
 function renderFloorSelector(current) {

--- a/public/index.html
+++ b/public/index.html
@@ -178,7 +178,7 @@
   }
   .floor-btn {
     flex: 1; padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius);
-    background: var(--card); cursor: pointer; text-align: left; font-family: inherit;
+    background: var(--card); color: var(--fg); cursor: pointer; text-align: left; font-family: inherit;
     transition: border-color 200ms, background 200ms;
   }
   .floor-btn:hover { border-color: var(--dim); }
@@ -186,10 +186,10 @@
     border-color: var(--accent); background: var(--accent-dim);
   }
   .floor-btn strong {
-    display: block; font-size: 13px; font-weight: 600; margin-bottom: 2px;
+    display: block; font-size: 13px; font-weight: 600; margin-bottom: 2px; color: var(--fg);
   }
   .floor-btn span {
-    font-size: 11px; color: var(--dim); line-height: 1.4;
+    font-size: 11px; color: var(--muted); line-height: 1.4;
   }
   @media (max-width: 640px) { .floor-row { flex-direction: column; } }
   .floor-warn {

--- a/public/index.html
+++ b/public/index.html
@@ -263,7 +263,8 @@ function softRefresh() {
   setText('v-sonnet', today.models.sonnet || 0);
   setText('v-haiku', today.models.haiku || 0);
   setText('v-deleg', today.delegations);
-  setText('v-cost', '~$' + (D.sessionCosts ? Object.values(D.sessionCosts.sessions||{}).reduce((a,s)=>a+s.estimatedCost,0).toFixed(2) : '0.00'));
+  const todayCost = D.todayTokenUsage ? D.todayTokenUsage.totalCost : (D.sessionCosts ? Object.values(D.sessionCosts.sessions||{}).reduce((a,s)=>a+s.estimatedCost,0) : 0);
+  setText('v-cost', '$' + todayCost.toFixed(2));
   setText('v-total', r.totalTasks + ' total');
   setText('v-tab-today', 'Today (' + today.totalTasks + ')');
   setSection('v-timeline', renderTimeline(tab));
@@ -305,7 +306,7 @@ function getEffectiveTab() {
 function buildHTML() {
   const D = DATA; if (!D) return '';
   const s = D.stats, r = D.routing, today = r.todayStats, tab = getEffectiveTab(), isDark = getTheme() === 'dark';
-  const totalCost = Object.values(D.sessionCosts?.sessions||{}).reduce((a,s)=>a+s.estimatedCost,0);
+  const totalCost = D.todayTokenUsage ? D.todayTokenUsage.totalCost : Object.values(D.sessionCosts?.sessions||{}).reduce((a,s)=>a+s.estimatedCost,0);
 
   return `
     <header class="hdr anim" role="banner">
@@ -323,7 +324,7 @@ function buildHTML() {
       <div class="metric"><span class="metric-val" id="v-sonnet">${today.models.sonnet||0}</span><span class="metric-label">sonnet</span></div>
       <div class="metric"><span class="metric-val" id="v-haiku">${today.models.haiku||0}</span><span class="metric-label">haiku</span></div>
       <div class="metric"><span class="metric-val" id="v-deleg">${today.delegations}</span><span class="metric-label">delegated</span></div>
-      <div class="metric metric-accent"><span class="metric-val" id="v-cost">~$${totalCost.toFixed(2)}</span><span class="metric-label">est. today</span></div>
+      <div class="metric metric-accent"><span class="metric-val" id="v-cost">$${totalCost.toFixed(2)}</span><span class="metric-label">cost today</span></div>
     </div>
 
     </section>
@@ -533,8 +534,8 @@ function renderSessionCosts(sc) {
   for (const [, s] of entries) { totalCost += s.estimatedCost; totalPrompts += s.prompts; }
 
   let html = `<div class="sc-summary">
-    <div><div class="sc-stat-val" style="color:var(--accent)">~$${totalCost.toFixed(2)}</div><div class="sc-stat-label">est. cost</div></div>
-    <div><div class="sc-stat-val">${totalPrompts}</div><div class="sc-stat-label">prompts</div></div>
+    <div><div class="sc-stat-val" style="color:var(--accent)">$${totalCost.toFixed(2)}</div><div class="sc-stat-label">cost today</div></div>
+    <div><div class="sc-stat-val">${totalPrompts}</div><div class="sc-stat-label">API calls</div></div>
     <div><div class="sc-stat-val">${entries.length}</div><div class="sc-stat-label">sessions</div></div>
   </div>`;
 
@@ -548,7 +549,7 @@ function renderSessionCosts(sc) {
         <div style="margin-top:2px">${models}</div>
       </div>
       <div style="text-align:right">
-        <div style="font-family:var(--mono);font-size:13px;font-weight:600;font-variant-numeric:tabular-nums">~$${s.estimatedCost.toFixed(2)}</div>
+        <div style="font-family:var(--mono);font-size:13px;font-weight:600;font-variant-numeric:tabular-nums">$${s.estimatedCost.toFixed(2)}</div>
         <div style="font-size:11px;color:var(--dim)">${s.prompts} prompts &middot; ${time}</div>
       </div>
     </div>`;

--- a/public/index.html
+++ b/public/index.html
@@ -457,6 +457,7 @@ function buildHTML() {
           <h2>Routing decisions</h2>
           <span class="ct" id="v-total">${r.totalTasks} total</span>
         </div>
+        <div style="font-size:12px;color:var(--dim);margin-bottom:10px;line-height:1.5">Each time you send a prompt, Token Coach decides whether to use a cheaper model instead of opus. This log shows those decisions — your main session runs on opus separately.</div>
         <div id="v-rd-strip" style="display:flex;gap:8px 14px;flex-wrap:wrap;margin-bottom:10px;font-size:11px;color:var(--dim)">${renderRoutingStrip(D.routingEvents)}</div>
         <div class="tabs" role="tablist" aria-label="Timeline time range">
           <button class="tab ${tab==='today'?'on':''}" onclick="setTab('today')" id="v-tab-today" role="tab" aria-selected="${tab==='today'}" aria-controls="v-timeline">Today (${today.totalTasks})</button>

--- a/public/index.html
+++ b/public/index.html
@@ -297,6 +297,18 @@
 let DATA = null;
 let activeFilter = 'all';
 let timelineTab = 'auto';
+let activeProject = 'all';
+
+/** Turn a path-based project slug into a clean display name */
+function cleanProject(slug) {
+  if (!slug) return 'unknown';
+  // Strip leading path segments like "-home-cchhita-"
+  const parts = slug.replace(/^-/, '').split('-');
+  // Find the last meaningful segment (skip home, username)
+  if (parts.length >= 3) return parts.slice(2).join('-');
+  if (parts.length === 2) return parts[1];
+  return slug;
+}
 
 function getTheme() { return localStorage.getItem('token-coach-theme') || 'dark'; }
 function setTheme(t) { localStorage.setItem('token-coach-theme', t); document.documentElement.setAttribute('data-theme', t === 'dark' ? 'dark' : ''); }
@@ -444,6 +456,7 @@ function buildHTML() {
         <h2>Session costs</h2>
         <span class="ct" id="v-sc-ct">${Object.keys(D.sessionCosts?.sessions||{}).length} today</span>
       </div>
+      <div class="filters" id="v-sc-filters" role="toolbar" aria-label="Filter by project">${renderProjectFilters(D.sessionCosts)}</div>
       <div id="v-sc-body">${renderSessionCosts(D.sessionCosts)}</div>
     </div>
 
@@ -651,19 +664,70 @@ function renderRoutingStrip(re) {
     <span style="color:#16a34a;font-weight:600">~$${savedEst} estimated savings</span>`;
 }
 
+function renderProjectFilters(sc) {
+  const sessions = sc?.sessions || {};
+  const projects = new Set();
+  for (const [, s] of Object.values(sessions).length ? Object.entries(sessions) : []) {
+    projects.add(s.project || 'unknown');
+  }
+  const sorted = [...projects].sort();
+  if (sorted.length <= 1) return ''; // No filter needed for 0-1 projects
+  let html = `<button class="flt ${activeProject==='all'?'on':''}" onclick="setProject('all')" aria-pressed="${activeProject==='all'}">all</button>`;
+  for (const p of sorted) {
+    const label = cleanProject(p);
+    html += `<button class="flt ${activeProject===p?'on':''}" onclick="setProject('${esc(p)}')" aria-pressed="${activeProject===p}">${esc(label)}</button>`;
+  }
+  return html;
+}
+
+function setProject(proj) {
+  activeProject = proj;
+  if (DATA) {
+    document.getElementById('v-sc-body').innerHTML = renderSessionCosts(DATA.sessionCosts);
+    document.getElementById('v-sc-filters').innerHTML = renderProjectFilters(DATA.sessionCosts);
+    // Update the count badge
+    const sessions = DATA.sessionCosts?.sessions || {};
+    const filtered = activeProject === 'all'
+      ? Object.keys(sessions).length
+      : Object.entries(sessions).filter(([, s]) => s.project === activeProject).length;
+    document.getElementById('v-sc-ct').textContent = filtered + ' sessions';
+  }
+}
+
 function renderSessionCosts(sc) {
   const sessions = sc?.sessions || {};
-  const entries = Object.entries(sessions).sort((a, b) => (b[1].lastActivity||'').localeCompare(a[1].lastActivity||''));
+  let entries = Object.entries(sessions).sort((a, b) => (b[1].lastActivity||'').localeCompare(a[1].lastActivity||''));
   if (!entries.length) return '<div class="empty">No session data yet.</div>';
 
+  // Apply project filter
+  if (activeProject !== 'all') {
+    entries = entries.filter(([, s]) => s.project === activeProject);
+    if (!entries.length) return '<div class="empty">No sessions for this project.</div>';
+  }
+
   let totalCost = 0, totalPrompts = 0;
-  for (const [, s] of entries) { totalCost += s.estimatedCost; totalPrompts += s.prompts; }
+  const modelTotals = {};
+  for (const [, s] of entries) {
+    totalCost += s.estimatedCost;
+    totalPrompts += s.prompts;
+    for (const [m, c] of Object.entries(s.models || {})) {
+      modelTotals[m] = (modelTotals[m] || 0) + c;
+    }
+  }
+  const modelBreakdown = Object.entries(modelTotals)
+    .sort((a, b) => b[1] - a[1])
+    .map(([m, c]) => `<span class="ml ml-${m}">${m}</span>&nbsp;${c}`)
+    .join('&nbsp;&nbsp;&nbsp;');
 
   let html = `<div class="sc-summary">
-    <div><div class="sc-stat-val" style="color:var(--accent)">$${totalCost.toFixed(2)}</div><div class="sc-stat-label">cost today</div></div>
+    <div><div class="sc-stat-val" style="color:var(--accent)">$${totalCost.toFixed(2)}</div><div class="sc-stat-label">cost${activeProject !== 'all' ? '' : ' today'}</div></div>
     <div><div class="sc-stat-val">${totalPrompts}</div><div class="sc-stat-label">API calls</div></div>
     <div><div class="sc-stat-val">${entries.length}</div><div class="sc-stat-label">sessions</div></div>
   </div>`;
+
+  if (modelBreakdown) {
+    html += `<div style="margin-bottom:10px;font-size:11px;color:var(--dim)">${modelBreakdown}</div>`;
+  }
 
   html += '<div style="max-height:240px;overflow-y:auto;scrollbar-width:thin;scrollbar-color:var(--faint) transparent">';
   for (const [sid, s] of entries) {
@@ -671,7 +735,7 @@ function renderSessionCosts(sc) {
     const models = Object.entries(s.models||{}).map(([m,c]) => `<span class="ml ml-${m}">${m}</span> <span style="color:var(--dim);font-size:11px">&times;${c}</span>`).join('&nbsp;&nbsp;');
     html += `<div class="sc-row">
       <div>
-        <div style="font-size:13px;font-weight:500">${esc(s.project)} <span style="color:var(--dim);font-weight:400;font-size:11px;font-family:var(--mono)">${sid.slice(0,8)}</span></div>
+        <div style="font-size:13px;font-weight:500">${esc(cleanProject(s.project))} <span style="color:var(--dim);font-weight:400;font-size:11px;font-family:var(--mono)">${sid.slice(0,8)}</span></div>
         <div style="margin-top:2px">${models}</div>
       </div>
       <div style="text-align:right">

--- a/public/index.html
+++ b/public/index.html
@@ -200,13 +200,25 @@
   .tl-row:last-child { border-bottom: none; }
   .tl-time { font-family: var(--mono); font-size: 11px; color: var(--dim); width: 40px; flex-shrink: 0; padding-top: 2px; }
   .tl-time small { display: block; font-size: 10px; color: var(--dim); opacity: 0.6; }
-  .tl-model { flex-shrink: 0; min-width: 56px; padding-top: 2px; }
+  .tl-model { flex-shrink: 0; min-width: 140px; padding-top: 2px; }
   .tl-body { flex: 1; min-width: 0; }
   .tl-desc { font-size: 13px; color: var(--muted); line-height: 1.4; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .tl-meta { display: flex; gap: 8px; margin-top: 2px; align-items: center; }
   .tl-proj { font-size: 11px; color: var(--dim); font-weight: 500; }
   .tl-sz { font-family: var(--mono); font-size: 10px; color: var(--dim); }
-  .deleg-hint { color: var(--dim); font-size: 10px; margin-left: 4px; font-weight: 400; font-family: inherit; }
+  .tl-badge {
+    display: inline-block; font-size: 10px; padding: 1px 6px; border-radius: 3px;
+    margin-left: 4px; font-weight: 500; vertical-align: 1px; white-space: nowrap;
+  }
+  .tl-badge-down { color: #16a34a; background: rgba(22, 163, 74, 0.1); }
+  .tl-badge-up { color: var(--danger); background: var(--danger-dim); }
+  .tl-badge-stay { color: var(--dim); background: var(--separator); }
+  [data-theme="dark"] .tl-badge-down { color: #4ade80; background: rgba(22, 163, 74, 0.12); }
+  .tl-saved {
+    font-family: var(--mono); font-size: 11px; color: #16a34a; font-weight: 600;
+    margin-left: 8px; white-space: nowrap;
+  }
+  [data-theme="dark"] .tl-saved { color: #4ade80; }
 
   /* ─── Insights ───────────────────────────── */
   .ins-item {
@@ -518,21 +530,42 @@ function renderTimeline(tab) {
   if (activeFilter !== 'all') entries = entries.filter(t => t.model.includes(activeFilter));
   if (!entries.length) return `<div class="empty">${tab === 'today' ? 'No tasks today' : 'No matching tasks'}</div>`;
 
+  // Approximate cost per prompt by model (USD) — rough estimates for display
+  const promptCost = { opus: 0.10, sonnet: 0.03, haiku: 0.005 };
+
   return (tab === 'today' ? entries : entries.slice(0, 60)).map(t => {
-    const isDel = t.model.includes('>');
     const time = t.timestamp.slice(11, 16);
-    let ml;
-    if (isDel) {
-      const [, tgt] = t.model.split('>');
-      ml = modelLabel(tgt) + '<span class="deleg-hint">subagent</span>';
+    // Handle legacy "opus>sonnet" format
+    const isDel = t.model.includes('>');
+    const finalModel = isDel ? t.model.split('>')[1] : t.model;
+    const baseModel = isDel ? t.model.split('>')[0] : (t.baseModel || null);
+
+    // Build the routing story
+    let badge = '';
+    let savings = '';
+    const tier = { haiku: 0, sonnet: 1, opus: 2 };
+    const finalTier = tier[finalModel] ?? 1;
+    const baseTier = baseModel ? (tier[baseModel] ?? 1) : finalTier;
+
+    if (t.isSubagent) {
+      badge = '<span class="tl-badge tl-badge-down">subagent</span>';
+      const saved = (promptCost[baseModel] || 0) - (promptCost[finalModel] || 0);
+      if (saved > 0) savings = `<span class="tl-saved">saved ~$${saved.toFixed(2)}</span>`;
+    } else if (baseModel && baseTier > finalTier) {
+      badge = `<span class="tl-badge tl-badge-down">↓ saved from ${baseModel}</span>`;
+      const saved = (promptCost[baseModel] || 0) - (promptCost[finalModel] || 0);
+      if (saved > 0) savings = `<span class="tl-saved">~$${saved.toFixed(2)} saved</span>`;
+    } else if (baseModel && baseTier < finalTier) {
+      badge = `<span class="tl-badge tl-badge-up">↑ upgraded from ${baseModel}</span>`;
     } else {
-      ml = modelLabel(t.model);
+      badge = '<span class="tl-badge tl-badge-stay">stayed at floor</span>';
     }
+
     return `<div class="tl-row">
       <div class="tl-time">${time}${tab==='all'?`<small>${t.timestamp.slice(5,10)}</small>`:''}</div>
-      <div class="tl-model">${ml}</div>
+      <div class="tl-model">${modelLabel(finalModel)}${badge}</div>
       <div class="tl-body">
-        <div class="tl-desc">${esc(t.description)}</div>
+        <div class="tl-desc">${esc(t.description)}${savings}</div>
         <div class="tl-meta"><span class="tl-proj">${esc(t.project)}</span><span class="tl-sz">${t.size}</span></div>
       </div>
     </div>`;
@@ -608,13 +641,14 @@ function renderTokenHogs(hogs) {
 function renderRoutingStrip(re) {
   if (!re?.stats) return '';
   const s = re.stats, rec = s.byRecommended || {};
-  return `<span style="font-weight:600;color:var(--muted)">Router recommendations:</span>
-    <span><strong style="font-family:var(--mono)">${s.total||0}</strong> classified</span>
-    <span><strong style="font-family:var(--mono)">${rec.haiku||0}</strong> haiku</span>
-    <span><strong style="font-family:var(--mono)">${rec.sonnet||0}</strong> sonnet</span>
-    <span><strong style="font-family:var(--mono)">${rec.opus||0}</strong> opus</span>
-    <span><strong style="font-family:var(--mono)">${s.delegated||0}</strong> sent to subagents</span>
-    <span><strong style="font-family:var(--mono)">${s.delegationRate||0}%</strong> routed cheaper</span>`;
+  // Estimate savings: count how many tasks were downgraded from opus
+  const downgraded = (rec.haiku || 0) + (rec.sonnet || 0);
+  const savedEst = downgraded > 0 ? (downgraded * 0.07).toFixed(2) : '0.00'; // ~$0.07 avg savings per downgrade
+  return `<span><strong style="font-family:var(--mono)">${s.total||0}</strong> tasks routed</span>
+    <span><strong style="font-family:var(--mono)">${rec.opus||0}</strong> on opus</span>
+    <span><strong style="font-family:var(--mono)">${rec.sonnet||0}</strong> on sonnet</span>
+    <span><strong style="font-family:var(--mono)">${rec.haiku||0}</strong> on haiku</span>
+    <span style="color:#16a34a;font-weight:600">~$${savedEst} estimated savings</span>`;
 }
 
 function renderSessionCosts(sc) {

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -153,6 +153,77 @@ function estimateSessionCost(messageCount, model = 'opus') {
   return ((inputTokens / m) * price.input) + ((outputTokens / m) * price.output);
 }
 
+/**
+ * Calculate counterfactual cost: what would it have cost if everything ran on opus?
+ * @param {object} byModel — { opus: { input, output, cacheRead, cacheWrite, cost }, sonnet: ..., haiku: ... }
+ *   Token counts per model tier (from readSessionTokenUsage().byModel)
+ */
+function calculateCounterfactual(byModel) {
+  if (!byModel) return { actual: 0, counterfactual: 0, savings: 0, savingsPercent: 0 };
+
+  const opusPrice = getModelPrice('opus');
+  const m = 1_000_000;
+  let actual = 0;
+  let counterfactual = 0;
+
+  for (const [tier, data] of Object.entries(byModel)) {
+    actual += data.cost || 0;
+    // Reprice all tokens at opus rates
+    const inp = data.input || 0;
+    const out = data.output || 0;
+    const cr = data.cacheRead || 0;
+    const cw = data.cacheWrite || 0;
+    counterfactual += (inp / m * opusPrice.input) +
+      (out / m * opusPrice.output) +
+      (cr / m * opusPrice.cacheRead) +
+      (cw / m * opusPrice.cacheWrite);
+  }
+
+  return {
+    actual,
+    counterfactual,
+    savings: counterfactual - actual,
+    savingsPercent: counterfactual > 0 ? ((counterfactual - actual) / counterfactual * 100) : 0,
+  };
+}
+
+/**
+ * Estimate daily actual vs counterfactual from dailyModelTokens (stats-cache).
+ * Uses a blended cost-per-token since we don't have input/output split per day.
+ * @param {Array} dailyModelTokens — [{ date, tokensByModel: { "claude-opus-4-6": N, ... } }]
+ * @param {number} days — number of days to return
+ */
+function calculateDailySavings(dailyModelTokens, days = 14) {
+  if (!dailyModelTokens?.length) return [];
+
+  // Blended cost-per-token for each tier (weighted average of input+output+cache pricing)
+  // Based on typical ratios: ~60% cache-read, ~30% input, ~8% output, ~2% cache-write
+  function blendedRate(modelId) {
+    const p = getModelPrice(modelId);
+    return (p.input * 0.30 + p.output * 0.08 + p.cacheRead * 0.60 + p.cacheWrite * 0.02);
+  }
+  const opusBlended = blendedRate('opus');
+
+  return dailyModelTokens.slice(-days).map(d => {
+    let actual = 0;
+    let counterfactual = 0;
+    const m = 1_000_000;
+
+    for (const [modelId, tokens] of Object.entries(d.tokensByModel || {})) {
+      const rate = blendedRate(modelId);
+      actual += (tokens / m) * rate;
+      counterfactual += (tokens / m) * opusBlended;
+    }
+
+    return {
+      date: d.date,
+      actual: Math.round(actual * 100) / 100,
+      counterfactual: Math.round(counterfactual * 100) / 100,
+      savings: Math.round((counterfactual - actual) * 100) / 100,
+    };
+  });
+}
+
 module.exports = {
   PRICING,
   getModelPrice,
@@ -161,4 +232,6 @@ module.exports = {
   calculateTotalCosts,
   calculateOptimalCost,
   estimateSessionCost,
+  calculateCounterfactual,
+  calculateDailySavings,
 };

--- a/src/config.js
+++ b/src/config.js
@@ -6,8 +6,13 @@ const fs = require('fs');
 const dataHome = require('./data-home');
 
 const DEFAULTS = {
-  // Routing preference: 0 = cheapest possible, 50 = balanced, 100 = max quality
-  // Default 35 = sonnet-heavy (protects users from token burn)
+  // Model floor: the starting model for all tasks.
+  // 'haiku'  — start everything on haiku, only upgrade when needed
+  // 'sonnet' — start on sonnet, upgrade to opus for complex work (default)
+  // 'opus'   — everything runs on opus, no routing
+  model_floor: 'sonnet',
+
+  // Legacy — kept for backward compat; ignored when model_floor is set explicitly.
   routing_preference: 35,
 
   // Daily budget alerts (USD). null = disabled.
@@ -24,6 +29,20 @@ function configPath() {
   return dataHome.getConfigPath();
 }
 
+/** Map legacy routing_preference to model_floor. */
+function migratePreference(user) {
+  // If user already set model_floor explicitly, skip migration
+  if (user.model_floor) return user;
+  // If they have a routing_preference, derive model_floor from it
+  if (user.routing_preference != null) {
+    const pref = user.routing_preference;
+    if (pref <= 25) user.model_floor = 'haiku';
+    else if (pref <= 75) user.model_floor = 'sonnet';
+    else user.model_floor = 'opus';
+  }
+  return user;
+}
+
 /** Read config, merging user values over defaults. */
 function read() {
   if (_cache) return _cache;
@@ -32,7 +51,7 @@ function read() {
   if (fs.existsSync(fp)) {
     try { user = JSON.parse(fs.readFileSync(fp, 'utf-8')); } catch {}
   }
-  _cache = { ...DEFAULTS, ...user };
+  _cache = { ...DEFAULTS, ...migratePreference(user) };
   return _cache;
 }
 

--- a/src/events.js
+++ b/src/events.js
@@ -118,53 +118,62 @@ function getRoutingStats(opts = {}) {
 }
 
 /**
- * Estimate cost per prompt based on model tier.
- * Rough estimates: avg ~2000 input tokens + ~800 output per prompt turn.
- * Subagent dispatches add ~1500 input + ~600 output.
- */
-const COST_PER_PROMPT = {
-  haiku:  { input: 2000, output: 800, priceIn: 1.00, priceOut: 5.00 },
-  sonnet: { input: 2000, output: 800, priceIn: 3.00, priceOut: 15.00 },
-  opus:   { input: 2000, output: 800, priceIn: 15.00, priceOut: 75.00 },
-};
-
-function estimatePromptCost(model) {
-  const tier = (model || 'opus').includes('opus') ? 'opus'
-    : (model || '').includes('sonnet') ? 'sonnet'
-    : (model || '').includes('haiku') ? 'haiku' : 'opus';
-  const c = COST_PER_PROMPT[tier];
-  const m = 1_000_000;
-  return (c.input / m * c.priceIn) + (c.output / m * c.priceOut);
-}
-
-/**
- * Get per-session cost estimates from today's events.
+ * Get per-session costs from actual Claude Code session token usage.
+ * Reads real token counts from session JSONL files instead of estimating.
  * Returns { sessions: { [session_id]: { prompts, estimatedCost, models, lastActivity } } }
  */
 function getSessionCosts() {
+  const parser = require('./parser');
   const todayStr = today();
-  const allEvents = readEvents({ since: todayStr });
-  const sessions = {};
 
+  // Get real token usage from session files
+  const realUsage = parser.readSessionTokenUsage(todayStr);
+
+  // Also get event data for metadata (lastActivity, project names, prompt counts)
+  const allEvents = readEvents({ since: todayStr });
+  const eventMeta = {};
   for (const ev of allEvents) {
     const sid = ev.session_id;
     if (!sid) continue;
-
-    if (!sessions[sid]) {
-      sessions[sid] = { prompts: 0, estimatedCost: 0, models: {}, lastActivity: ev.ts, project: ev.project || 'unknown' };
+    if (!eventMeta[sid]) {
+      eventMeta[sid] = { prompts: 0, lastActivity: ev.ts, project: ev.project || 'unknown', models: {} };
     }
-    const s = sessions[sid];
-    s.lastActivity = ev.ts;
-
+    eventMeta[sid].lastActivity = ev.ts;
     if (ev.type === 'routing_decision') {
-      s.prompts++;
+      eventMeta[sid].prompts++;
       const model = ev.recommended_model || 'opus';
-      s.models[model] = (s.models[model] || 0) + 1;
-      s.estimatedCost += estimatePromptCost(model);
+      eventMeta[sid].models[model] = (eventMeta[sid].models[model] || 0) + 1;
     } else if (ev.type === 'subagent_dispatch') {
       const model = ev.model_used || 'sonnet';
-      s.models[model] = (s.models[model] || 0) + 1;
-      s.estimatedCost += estimatePromptCost(model);
+      eventMeta[sid].models[model] = (eventMeta[sid].models[model] || 0) + 1;
+    }
+  }
+
+  // Merge real usage with event metadata
+  const sessions = {};
+
+  // Add sessions from real token usage
+  for (const [sid, usage] of Object.entries(realUsage.bySession)) {
+    const meta = eventMeta[sid] || {};
+    sessions[sid] = {
+      prompts: usage.calls || meta.prompts || 0,
+      estimatedCost: usage.cost,
+      models: usage.models || meta.models || {},
+      lastActivity: meta.lastActivity || null,
+      project: usage.project || meta.project || 'unknown',
+    };
+  }
+
+  // Add sessions from events that weren't in session files (edge case)
+  for (const [sid, meta] of Object.entries(eventMeta)) {
+    if (!sessions[sid]) {
+      sessions[sid] = {
+        prompts: meta.prompts,
+        estimatedCost: 0, // no real data available
+        models: meta.models,
+        lastActivity: meta.lastActivity,
+        project: meta.project,
+      };
     }
   }
 
@@ -177,6 +186,17 @@ function getSessionCosts() {
 function getSessionCost(sessionId) {
   const { sessions } = getSessionCosts();
   return sessions[sessionId] || { prompts: 0, estimatedCost: 0, models: {}, lastActivity: null };
+}
+
+/**
+ * Legacy estimate — kept for fallback if session files aren't available.
+ */
+function estimatePromptCost(model) {
+  const tier = (model || 'opus').includes('opus') ? 'opus'
+    : (model || '').includes('sonnet') ? 'sonnet'
+    : (model || '').includes('haiku') ? 'haiku' : 'opus';
+  const costs = { haiku: 0.006, sonnet: 0.018, opus: 0.09 }; // rough per-prompt
+  return costs[tier] || costs.opus;
 }
 
 /**
@@ -236,6 +256,39 @@ function getTokenHogs() {
   };
 }
 
+/**
+ * Get the last N events for a specific session, optionally filtered by type.
+ * Reads only today's file for performance (sessions don't span days).
+ */
+function getSessionEvents(sessionId, opts = {}) {
+  if (!sessionId) return [];
+  const file = path.join(EVENTS_DIR, `${today()}.jsonl`);
+  if (!fs.existsSync(file)) return [];
+
+  const lines = fs.readFileSync(file, 'utf-8').trim().split('\n').filter(Boolean);
+  const results = [];
+
+  for (const line of lines) {
+    try {
+      const ev = JSON.parse(line);
+      if (ev.session_id !== sessionId) continue;
+      if (opts.type && ev.type !== opts.type) continue;
+      results.push(ev);
+    } catch {}
+  }
+
+  if (opts.limit) return results.slice(-opts.limit);
+  return results;
+}
+
+/**
+ * Get the most recent routing decision for a session.
+ */
+function getLastRoutingDecision(sessionId) {
+  const decisions = getSessionEvents(sessionId, { type: 'routing_decision' });
+  return decisions.length > 0 ? decisions[decisions.length - 1] : null;
+}
+
 module.exports = {
   logEvent,
   readEvents,
@@ -244,6 +297,8 @@ module.exports = {
   getSessionCost,
   estimatePromptCost,
   getTokenHogs,
+  getSessionEvents,
+  getLastRoutingDecision,
   DATA_DIR,
   EVENTS_DIR,
 };

--- a/src/insights.js
+++ b/src/insights.js
@@ -11,6 +11,29 @@ function generateInsights(data) {
   const { stats, history, sessions, dailyLogs, taskLog, projects, mcpServers } = data;
   const runWaste = detectWaste(data.runs || []);
 
+  // ─── Primary model mismatch check ─────────────────────────
+  try {
+    const config = require('./config');
+    const parser = require('./parser');
+    const floor = config.read().model_floor || 'sonnet';
+    const tu = parser.readSessionTokenUsage();
+    const bm = tu?.byModel || {};
+    const opusCalls = bm.opus?.calls || 0;
+    const total = opusCalls + (bm.sonnet?.calls || 0) + (bm.haiku?.calls || 0);
+    const opusPct = total > 0 ? Math.round(opusCalls / total * 100) : 0;
+    const opusCost = bm.opus?.cost || 0;
+
+    if (floor !== 'opus' && opusPct > 70 && total > 10) {
+      insights.push({
+        _live: true,
+        severity: 'warning',
+        title: `${opusPct}% of API calls still run on opus ($${opusCost.toFixed(2)} today)`,
+        detail: `Your model floor is set to ${floor}, but your main Claude Code session is running on opus. The floor only affects subagent routing — the primary session model is set when you start Claude Code.`,
+        action: `Start Claude Code with: claude --model ${floor}. Token Coach will still upgrade to opus when a task needs it.`,
+      });
+    }
+  } catch {}
+
   // ─── Live Routing Insights (from hooks — always fresh) ────
   const routingStats = events.getRoutingStats();
 

--- a/src/insights.js
+++ b/src/insights.js
@@ -237,20 +237,124 @@ function generateInsights(data) {
     }
   }
 
-  // ─── MCP Server Analysis ───────────────────────────────────
+  // ─── MCP Server Analysis (#52) ────────────────────────────
   if (mcpServers) {
     for (const [projectName, serverInfo] of Object.entries(mcpServers)) {
       const { enabled, disabled, projectPath } = serverInfo;
-      if (enabled.length > 5) {
-        insights.push({
-          severity: 'warning',
-          title: `${projectName}: ${enabled.length} MCP servers active`,
-          detail: `Active servers: ${enabled.join(', ')}. Each MCP server adds tool definitions to the system prompt, consuming tokens on every message. Disabled: ${disabled.length > 0 ? disabled.join(', ') : 'none'}.`,
-          action: `Disable unused MCP servers in ${projectPath}/.claude/settings.json → disabledMcpServers. Only keep servers this project actually uses.`,
-        });
-      }
+      if (enabled.length === 0) continue;
+      // ~800 tokens overhead per server per message (tool definitions in system prompt)
+      const tokenOverheadPerMsg = enabled.length * 800;
+      const msgs = stats?.totalMessages || 0;
+      const msgsToday = (stats?.dailyActivity || []).slice(-1)[0]?.messageCount || 0;
+      const opusPrice = 15 / 1_000_000; // input cost per token
+      const dailyCostEst = msgsToday * tokenOverheadPerMsg * opusPrice;
+      const severity = enabled.length >= 5 ? 'critical' : enabled.length >= 3 ? 'warning' : 'info';
+      insights.push({
+        _live: true,
+        severity,
+        title: `${projectName}: ${enabled.length} MCP server${enabled.length > 1 ? 's' : ''} active — ~${(tokenOverheadPerMsg / 1000).toFixed(1)}K tokens per message`,
+        detail: `Active: ${enabled.join(', ')}. Every message you send includes all MCP server tool definitions in the system prompt${dailyCostEst > 0.01 ? ` — estimated $${dailyCostEst.toFixed(2)}/day overhead` : ''}. Disabled: ${disabled.length > 0 ? disabled.join(', ') : 'none'}.`,
+        action: `Disable unused servers in ${projectPath}/.claude/settings.json → disabledMcpServers. Only keep servers this project actually uses.`,
+      });
     }
   }
+
+  // ─── CLAUDE.md Bloat Detection (#53) ──────────────────────
+  try {
+    const os = require('os');
+    const fs = require('fs');
+    const path = require('path');
+    const claudeMdPaths = [
+      { file: path.join(os.homedir(), '.claude', 'CLAUDE.md'), label: '~/.claude/CLAUDE.md' },
+      { file: path.join(os.homedir(), 'CLAUDE.md'), label: '~/CLAUDE.md' },
+    ];
+    let totalTokens = 0;
+    const breakdown = [];
+    for (const { file, label } of claudeMdPaths) {
+      if (fs.existsSync(file)) {
+        const size = fs.readFileSync(file, 'utf-8').length;
+        const tokens = Math.round(size / 4); // ~4 chars per token
+        totalTokens += tokens;
+        breakdown.push(`${label}: ~${tokens.toLocaleString()} tokens`);
+      }
+    }
+    if (totalTokens > 1000) {
+      const msgsToday = (stats?.dailyActivity || []).slice(-1)[0]?.messageCount || 0;
+      const opusPrice = 15 / 1_000_000;
+      const dailyCost = msgsToday * totalTokens * opusPrice;
+      const severity = totalTokens > 4000 ? 'critical' : totalTokens > 2000 ? 'warning' : 'info';
+      insights.push({
+        _live: true,
+        severity,
+        title: `CLAUDE.md adds ~${totalTokens.toLocaleString()} tokens to every message${dailyCost > 0.05 ? ` (~$${dailyCost.toFixed(2)}/day)` : ''}`,
+        detail: `Your global instructions are included in every prompt. ${breakdown.join(', ')}. The larger these files, the more every conversation costs — even quick questions.`,
+        action: 'Move project-specific rules into per-project CLAUDE.md files. Keep the global ~/.claude/CLAUDE.md focused on truly universal preferences only.',
+      });
+    }
+  } catch {}
+
+  // ─── Repeated Tool Call Detection (#54) ───────────────────
+  try {
+    const recentEvents = events.readEvents({ limit: 500 });
+    const toolCalls = recentEvents.filter(e => e.type === 'tool_call');
+
+    // Group by session, then find repeated file reads and bash commands
+    const bySession = {};
+    for (const ev of toolCalls) {
+      const sid = ev.session_id || 'unknown';
+      if (!bySession[sid]) bySession[sid] = [];
+      bySession[sid].push(ev);
+    }
+
+    const repeatedReads = {}; // "filepath" -> count across all sessions today
+    const repeatedBash = {};  // "command_prefix" -> count
+
+    for (const calls of Object.values(bySession)) {
+      const readCounts = {};
+      const bashCounts = {};
+      for (const ev of calls) {
+        if (ev.tool === 'Read') {
+          // Extract file path from summary like "write /path/to/file" or just the path
+          const fp = (ev.summary || '').replace(/^(read|write|edit)\s+/i, '').trim().slice(0, 80);
+          if (fp) readCounts[fp] = (readCounts[fp] || 0) + 1;
+        }
+        if (ev.tool === 'Bash') {
+          const cmd = (ev.summary || '').slice(0, 50).trim();
+          if (cmd) bashCounts[cmd] = (bashCounts[cmd] || 0) + 1;
+        }
+      }
+      for (const [fp, count] of Object.entries(readCounts)) {
+        if (count >= 3) repeatedReads[fp] = Math.max(repeatedReads[fp] || 0, count);
+      }
+      for (const [cmd, count] of Object.entries(bashCounts)) {
+        if (count >= 3) repeatedBash[cmd] = Math.max(repeatedBash[cmd] || 0, count);
+      }
+    }
+
+    const topReads = Object.entries(repeatedReads).sort((a, b) => b[1] - a[1]).slice(0, 3);
+    const topBash = Object.entries(repeatedBash).sort((a, b) => b[1] - a[1]).slice(0, 2);
+
+    if (topReads.length > 0) {
+      const examples = topReads.map(([fp, n]) => `"${fp.split('/').pop()}" ×${n}`).join(', ');
+      insights.push({
+        _live: true,
+        severity: 'warning',
+        title: `Repeated file reads detected: ${examples}`,
+        detail: `The same files are being read multiple times per session. Each re-read sends the full file content again, wasting tokens. Files: ${topReads.map(([fp, n]) => `${fp} (×${n})`).join('; ')}.`,
+        action: 'Read files once and keep results in context. Use the Read tool at the start of a task, not repeatedly throughout.',
+      });
+    }
+    if (topBash.length > 0) {
+      const examples = topBash.map(([cmd, n]) => `"${cmd.slice(0, 30)}" ×${n}`).join(', ');
+      insights.push({
+        _live: true,
+        severity: 'info',
+        title: `Repeated commands detected: ${examples}`,
+        detail: `The same shell commands are running multiple times. Repeated polling or status checks burn tokens without adding new information.`,
+        action: 'Cache command output where possible. Avoid re-running the same diagnostic commands — read the result once and proceed.',
+      });
+    }
+  } catch {}
 
   // ─── Rate Limit Analysis ───────────────────────────────────
   if (dailyLogs) {

--- a/src/insights.js
+++ b/src/insights.js
@@ -239,22 +239,44 @@ function generateInsights(data) {
 
   // ─── MCP Server Analysis (#52) ────────────────────────────
   if (mcpServers) {
-    for (const [projectName, serverInfo] of Object.entries(mcpServers)) {
-      const { enabled, disabled, projectPath } = serverInfo;
-      if (enabled.length === 0) continue;
-      // ~800 tokens overhead per server per message (tool definitions in system prompt)
-      const tokenOverheadPerMsg = enabled.length * 800;
-      const msgs = stats?.totalMessages || 0;
+    // Find the common (global) servers shared across all projects
+    const allProjects = Object.entries(mcpServers).filter(([, info]) => info.enabled.length > 0);
+    const globalServers = allProjects.length > 0
+      ? allProjects.reduce((common, [, info]) => common.filter(s => info.enabled.includes(s)), allProjects[0]?.[1]?.enabled || [])
+      : [];
+
+    // Show one aggregated insight for global MCP servers
+    if (globalServers.length > 0) {
+      const tokenOverheadPerMsg = globalServers.length * 800;
       const msgsToday = (stats?.dailyActivity || []).slice(-1)[0]?.messageCount || 0;
-      const opusPrice = 15 / 1_000_000; // input cost per token
+      const opusPrice = 15 / 1_000_000;
+      const dailyCostEst = msgsToday * tokenOverheadPerMsg * opusPrice;
+      const severity = globalServers.length >= 5 ? 'critical' : globalServers.length >= 3 ? 'warning' : 'info';
+      insights.push({
+        _live: true,
+        severity,
+        title: `${globalServers.length} global MCP server${globalServers.length > 1 ? 's' : ''} active in all ${allProjects.length} projects — ~${(tokenOverheadPerMsg / 1000).toFixed(1)}K tokens/msg`,
+        detail: `Global servers: ${globalServers.join(', ')}. These are included in every message across all projects${dailyCostEst > 0.01 ? ` — estimated $${dailyCostEst.toFixed(2)}/day overhead` : ''}.`,
+        action: 'Disable unused global servers in ~/.mcp.json. Only keep servers you use across all projects.',
+      });
+    }
+
+    // Show per-project insights only for projects with EXTRA servers beyond global
+    for (const [projectName, serverInfo] of allProjects) {
+      const { enabled, disabled, projectPath } = serverInfo;
+      const extraServers = enabled.filter(s => !globalServers.includes(s));
+      if (extraServers.length === 0) continue;
+      const tokenOverheadPerMsg = extraServers.length * 800;
+      const msgsToday = (stats?.dailyActivity || []).slice(-1)[0]?.messageCount || 0;
+      const opusPrice = 15 / 1_000_000;
       const dailyCostEst = msgsToday * tokenOverheadPerMsg * opusPrice;
       const severity = enabled.length >= 5 ? 'critical' : enabled.length >= 3 ? 'warning' : 'info';
       insights.push({
         _live: true,
         severity,
-        title: `${projectName}: ${enabled.length} MCP server${enabled.length > 1 ? 's' : ''} active — ~${(tokenOverheadPerMsg / 1000).toFixed(1)}K tokens per message`,
-        detail: `Active: ${enabled.join(', ')}. Every message you send includes all MCP server tool definitions in the system prompt${dailyCostEst > 0.01 ? ` — estimated $${dailyCostEst.toFixed(2)}/day overhead` : ''}. Disabled: ${disabled.length > 0 ? disabled.join(', ') : 'none'}.`,
-        action: `Disable unused servers in ${projectPath}/.claude/settings.json → disabledMcpServers. Only keep servers this project actually uses.`,
+        title: `${projectName}: ${extraServers.length} extra MCP server${extraServers.length > 1 ? 's' : ''} — ~${(tokenOverheadPerMsg / 1000).toFixed(1)}K extra tokens/msg`,
+        detail: `Project-specific servers: ${extraServers.join(', ')} (plus ${globalServers.length} global). Total: ${enabled.length} servers${dailyCostEst > 0.01 ? ` — extra $${dailyCostEst.toFixed(2)}/day overhead` : ''}. Disabled: ${disabled.length > 0 ? disabled.join(', ') : 'none'}.`,
+        action: `Disable unused servers in ${projectPath}/.claude/settings.json → disabledMcpServers.`,
       });
     }
   }

--- a/src/learner.js
+++ b/src/learner.js
@@ -1,125 +1,160 @@
 /**
- * Adaptive learning — improves routing from historical dispatch data.
+ * Adaptive learning — improves routing from multi-signal outcome data.
  *
- * Tracks success rates per family×model from two data sources:
- * 1. Subagent dispatches (is_optimal field — did the dispatch match recommendation?)
- * 2. Escalation patterns (if a task was dispatched to haiku then re-dispatched to sonnet,
- *    haiku "failed" for that family)
+ * Replaces the old "routing compliance" signal (did the used model match
+ * the recommendation?) with a weighted outcome score derived from three
+ * independent signals:
  *
- * Uses a Bayesian-style approach:
- * - Start with prior confidence from hardcoded rules (the base recommendation)
- * - Update with observed data: success_rate = successes / total_samples
- * - Minimum 5 samples before adjusting (avoid overfitting to noise)
- * - Recent events weighted 2x vs older events (decay)
- * - Never downgrade architecture below opus (safety floor)
+ *   1. Turn outcome  (Stop vs StopFailure)         weight: 0.40
+ *   2. No escalation (wasn't re-dispatched higher)  weight: 0.35
+ *   3. No correction (next prompt isn't a fix)       weight: 0.25
  *
- * The learner produces "adjustments" that the router can apply:
- *   { family: "debug", model: "sonnet", confidence: 0.85, samples: 12, suggestion: "upgrade" }
+ * Each signal is 0 or 1. The weighted average produces a score in [0, 1].
+ * These scores are aggregated per family×model to produce routing adjustments.
+ *
+ * Minimum 5 outcome events before adjusting (avoid overfitting to noise).
+ * Recent events (within 14 days) get 2x weight.
+ * Never downgrade architecture below opus (safety floor).
  */
-const fs = require('fs');
-const path = require('path');
 const events = require('./events');
-const dataHome = require('./data-home');
 
 const MIN_SAMPLES = 5;
-const RECENCY_DAYS = 14; // Events within this window get 2x weight
+const RECENCY_DAYS = 14;
 const CACHE_TTL = 300_000; // 5 minutes
+
+// Signal weights — must sum to 1.0
+const WEIGHTS = {
+  turn_success: 0.40,
+  no_escalation: 0.35,
+  no_correction: 0.25,
+};
 
 let _cache = null;
 let _cacheTime = 0;
 
 /**
- * Build learning data from historical events.
- * Returns { byFamilyModel: { "debug:sonnet": { total, successes, failures, rate, samples } }, ... }
+ * Build learning data from outcome events and correction events.
+ * Returns { byFamilyModel: { "debug:sonnet": { total, weightedScore, ... } } }
  */
 function buildLearningData() {
   const now = Date.now();
   if (_cache && (now - _cacheTime) < CACHE_TTL) return _cache;
 
   const allEvents = events.readEvents({});
-  const dispatches = allEvents.filter(e => e.type === 'subagent_dispatch');
-  const decisions = allEvents.filter(e => e.type === 'routing_decision');
+  const outcomes = allEvents.filter(e => e.type === 'outcome');
+  const corrections = allEvents.filter(e => e.type === 'outcome_correction');
 
   const recencyThreshold = new Date(now - RECENCY_DAYS * 86400_000).toISOString();
 
-  // Track per family×model
+  // Index corrections by session for fast lookup
+  // A correction in session X means the previous turn in session X had a negative signal
+  const correctionsBySession = {};
+  for (const c of corrections) {
+    const sid = c.session_id;
+    if (!sid) continue;
+    if (!correctionsBySession[sid]) correctionsBySession[sid] = [];
+    correctionsBySession[sid].push(c);
+  }
+
   const stats = {};
 
   function getOrCreate(family, model) {
     const key = `${family}:${model}`;
-    if (!stats[key]) stats[key] = { family, model, total: 0, successes: 0, failures: 0, weightedTotal: 0, weightedSuccesses: 0 };
+    if (!stats[key]) {
+      stats[key] = {
+        family,
+        model,
+        total: 0,
+        weightedScoreSum: 0,
+        weightedTotal: 0,
+        // Per-signal tracking for dashboard visibility
+        signals: { turn_success: 0, no_escalation: 0, no_correction: 0 },
+        signalTotal: 0,
+      };
+    }
     return stats[key];
   }
 
-  // Source 1: Subagent dispatches — is_optimal tells us if the recommendation matched
+  for (const o of outcomes) {
+    const family = o.family || 'unknown';
+    const model = o.model || 'opus';
+    const isRecent = o.ts >= recencyThreshold;
+    const weight = isRecent ? 2 : 1;
+
+    // Signal 1: turn success (from outcome event)
+    const turnSuccess = o.turn_success ? 1 : 0;
+
+    // Signal 2: no escalation (from outcome event)
+    const noEscalation = o.was_escalated ? 0 : 1;
+
+    // Signal 3: no correction — check if a correction event followed in this session
+    // A correction event logged shortly after this outcome means the user was unhappy
+    const sessionCorrections = correctionsBySession[o.session_id] || [];
+    const wasFollowedByCorrection = sessionCorrections.some(c => {
+      if (!c.ts || !o.ts) return false;
+      const timeDiff = new Date(c.ts) - new Date(o.ts);
+      // Correction within 5 minutes of this outcome counts against it
+      return timeDiff > 0 && timeDiff < 300_000;
+    });
+    const noCorrection = wasFollowedByCorrection ? 0 : 1;
+
+    // Weighted outcome score for this single event
+    const score = (turnSuccess * WEIGHTS.turn_success) +
+                  (noEscalation * WEIGHTS.no_escalation) +
+                  (noCorrection * WEIGHTS.no_correction);
+
+    const entry = getOrCreate(family, model);
+    entry.total++;
+    entry.weightedScoreSum += score * weight;
+    entry.weightedTotal += weight;
+    entry.signalTotal++;
+    entry.signals.turn_success += turnSuccess;
+    entry.signals.no_escalation += noEscalation;
+    entry.signals.no_correction += noCorrection;
+  }
+
+  // ── Backfill from legacy data (subagent_dispatch events without outcomes) ──
+  // This keeps the learner useful during the transition period before enough
+  // outcome events accumulate. Legacy events get half weight.
+  const dispatches = allEvents.filter(e => e.type === 'subagent_dispatch');
+  const outcomeTimestamps = new Set(outcomes.map(o => o.session_id + ':' + (o.family || '')));
+
   for (const d of dispatches) {
     const cls = d.classification || {};
     const family = cls.family || 'unknown';
-    const usedModel = d.model_used || 'opus';
-    const recModel = d.recommended_model || 'sonnet';
-    const isRecent = d.ts >= recencyThreshold;
-    const weight = isRecent ? 2 : 1;
+    const sessionKey = d.session_id + ':' + family;
 
-    // Record success for the model that was used
+    // Skip if we already have outcome data for this session+family
+    if (outcomeTimestamps.has(sessionKey)) continue;
+
+    const usedModel = d.model_used || 'opus';
+    const isRecent = d.ts >= recencyThreshold;
+    const weight = (isRecent ? 2 : 1) * 0.5; // half weight for legacy
+
+    // Legacy signal: is_optimal (compliance) as a rough proxy
+    const score = d.is_optimal ? 0.8 : 0.3;
+
     const entry = getOrCreate(family, usedModel);
     entry.total++;
+    entry.weightedScoreSum += score * weight;
     entry.weightedTotal += weight;
-
-    if (d.is_optimal) {
-      // Used model matched recommendation — count as success for that model
-      entry.successes++;
-      entry.weightedSuccesses += weight;
-    } else {
-      // Used a more expensive model than recommended — the cheaper model "failed"
-      // (user/system decided it wasn't good enough)
-      entry.failures++;
-
-      // Also record that the recommended (cheaper) model was implicitly inadequate
-      const cheaperEntry = getOrCreate(family, recModel);
-      cheaperEntry.total++;
-      cheaperEntry.failures++;
-      cheaperEntry.weightedTotal += weight;
-    }
   }
 
-  // Source 2: Routing decisions that were NOT followed by a dispatch
-  // (the recommendation was used directly — implicit success for the recommended model)
-  const dispatchTimestamps = new Set(dispatches.map(d => d.ts).filter(Boolean));
-  for (const d of decisions) {
-    if (!d.ts) continue;
-    const cls = d.classification || {};
-    const family = cls.family || 'unknown';
-    const recModel = d.recommended_model || 'sonnet';
-    const isRecent = d.ts >= recencyThreshold;
-    const weight = isRecent ? 2 : 1;
-
-    // If this decision led to a dispatch, it's already counted above
-    // We approximate: if no dispatch within 5 seconds of this decision, it was used directly
-    const hasDispatch = dispatches.some(disp =>
-      disp.session_id === d.session_id &&
-      disp.ts && d.ts &&
-      Math.abs(new Date(disp.ts) - new Date(d.ts)) < 30_000
-    );
-
-    if (!hasDispatch) {
-      // Model was used directly (no delegation) — counts as success
-      const entry = getOrCreate(family, recModel);
-      entry.total++;
-      entry.successes++;
-      entry.weightedTotal += weight;
-      entry.weightedSuccesses += weight;
-    }
-  }
-
-  // Calculate rates
+  // Calculate final rates
   const result = {};
   for (const [key, s] of Object.entries(stats)) {
+    const weightedRate = s.weightedTotal > 0 ? s.weightedScoreSum / s.weightedTotal : 0;
     result[key] = {
       ...s,
-      rate: s.total > 0 ? s.successes / s.total : 0,
-      weightedRate: s.weightedTotal > 0 ? s.weightedSuccesses / s.weightedTotal : 0,
+      rate: weightedRate,
+      weightedRate,
       samples: s.total,
       meetsThreshold: s.total >= MIN_SAMPLES,
+      signalBreakdown: s.signalTotal > 0 ? {
+        turn_success: s.signals.turn_success / s.signalTotal,
+        no_escalation: s.signals.no_escalation / s.signalTotal,
+        no_correction: s.signals.no_correction / s.signalTotal,
+      } : null,
     };
   }
 
@@ -141,30 +176,29 @@ function getAdjustment(family, recommendedModel) {
 
   const rate = entry.weightedRate;
 
-  // If the recommended model succeeds >85% of the time — confirm it
-  if (rate >= 0.85) {
+  // High success (>0.80) — confirm the recommendation
+  if (rate >= 0.80) {
     return {
       suggestion: 'confirm',
-      reason: `${recommendedModel} succeeds ${Math.round(rate * 100)}% for ${family} (${entry.samples} samples)`,
+      reason: `${recommendedModel} scores ${Math.round(rate * 100)}% for ${family} (${entry.samples} outcomes)`,
       confidence: rate,
       samples: entry.samples,
     };
   }
 
-  // If success rate is low (<60%), suggest upgrading to a more capable model
-  if (rate < 0.60) {
+  // Low success (<0.55) — suggest upgrading to a more capable model
+  if (rate < 0.55) {
     const upgrade = recommendedModel === 'haiku' ? 'sonnet' : recommendedModel === 'sonnet' ? 'opus' : null;
     if (upgrade) {
-      // Check if the upgrade model has better stats
       const upgradeKey = `${family}:${upgrade}`;
       const upgradeEntry = data.byFamilyModel[upgradeKey];
-      const upgradeRate = upgradeEntry?.weightedRate || 0.5; // assume 50% if no data
+      const upgradeRate = upgradeEntry?.weightedRate || 0.5;
 
       if (upgradeRate > rate) {
         return {
           suggestion: 'upgrade',
           upgradeTo: upgrade,
-          reason: `${recommendedModel} only succeeds ${Math.round(rate * 100)}% for ${family} -- ${upgrade} at ${Math.round(upgradeRate * 100)}% (${entry.samples} samples)`,
+          reason: `${recommendedModel} scores ${Math.round(rate * 100)}% for ${family} -- ${upgrade} at ${Math.round(upgradeRate * 100)}% (${entry.samples} outcomes)`,
           confidence: rate,
           samples: entry.samples,
         };
@@ -172,19 +206,18 @@ function getAdjustment(family, recommendedModel) {
     }
   }
 
-  // If success rate is very high (>90%) and this is an expensive model, suggest downgrading
-  if (rate >= 0.90 && recommendedModel !== 'haiku') {
+  // Very high success (>0.85) on expensive model — suggest downgrading
+  if (rate >= 0.85 && recommendedModel !== 'haiku') {
     const downgrade = recommendedModel === 'opus' ? 'sonnet' : recommendedModel === 'sonnet' ? 'haiku' : null;
     if (downgrade) {
       const downgradeKey = `${family}:${downgrade}`;
       const downgradeEntry = data.byFamilyModel[downgradeKey];
 
-      // Only suggest downgrade if the cheaper model also has good stats (or no data = worth trying)
-      if (!downgradeEntry || !downgradeEntry.meetsThreshold || downgradeEntry.weightedRate >= 0.70) {
+      if (!downgradeEntry || !downgradeEntry.meetsThreshold || downgradeEntry.weightedRate >= 0.65) {
         return {
           suggestion: 'downgrade',
           downgradeTo: downgrade,
-          reason: `${recommendedModel} succeeds ${Math.round(rate * 100)}% for ${family} -- ${downgrade} may suffice (${entry.samples} samples)`,
+          reason: `${recommendedModel} scores ${Math.round(rate * 100)}% for ${family} -- ${downgrade} may suffice (${entry.samples} outcomes)`,
           confidence: rate,
           samples: entry.samples,
         };
@@ -210,11 +243,12 @@ function getLearningStats() {
       model: entry.model,
       rate: entry.weightedRate,
       samples: entry.samples,
+      signalBreakdown: entry.signalBreakdown,
       adjustment: adj,
     });
   }
 
-  // Sort by impact: upgrades first, then low-confidence entries
+  // Sort by impact: upgrades first, then low-score entries
   adjustments.sort((a, b) => {
     if (a.adjustment?.suggestion === 'upgrade' && b.adjustment?.suggestion !== 'upgrade') return -1;
     if (b.adjustment?.suggestion === 'upgrade' && a.adjustment?.suggestion !== 'upgrade') return 1;
@@ -226,6 +260,7 @@ function getLearningStats() {
     totalSamples: Object.values(data.byFamilyModel).reduce((s, e) => s + e.samples, 0),
     familiesTracked: new Set(Object.values(data.byFamilyModel).map(e => e.family)).size,
     generatedAt: data.generatedAt,
+    signalWeights: WEIGHTS,
   };
 }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -320,15 +320,15 @@ function readSessionTokenUsage(dateStr) {
   };
 
   function getTier(model) {
-    if (!model) return 'opus';
+    if (!model) return 'unknown';
     if (model.includes('opus')) return 'opus';
     if (model.includes('sonnet')) return 'sonnet';
     if (model.includes('haiku')) return 'haiku';
-    return 'opus';
+    return 'unknown';
   }
 
   function calcCost(tier, tokens) {
-    const p = pricing[tier] || pricing.opus;
+    const p = pricing[tier] || pricing.opus; // unknown models billed at opus rate (safe assumption)
     const m = 1_000_000;
     return (tokens.input / m * p.input) +
            (tokens.output / m * p.output) +
@@ -336,14 +336,18 @@ function readSessionTokenUsage(dateStr) {
            (tokens.cacheWrite / m * p.cacheWrite);
   }
 
-  // Convert Date to local YYYY-MM-DD string
-  function toLocalDate(d) {
+  // Convert a UTC ISO timestamp string to local YYYY-MM-DD
+  function utcToLocalDate(isoStr) {
+    const d = new Date(isoStr);
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
   }
 
-  // Recursively find all .jsonl files under projects dir, filtered by mtime
+  // Recursively find all .jsonl files under projects dir.
+  // We no longer filter by mtime — instead we rely on per-message timestamp filtering.
+  // Only skip files that haven't been modified in 7+ days to avoid scanning ancient files.
   function findJsonlFiles(dir, project, sessionId) {
     const results = [];
+    const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000; // 7 days ago
     let entries;
     try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return results; }
     for (const entry of entries) {
@@ -355,11 +359,10 @@ function readSessionTokenUsage(dateStr) {
       } else if (entry.name.endsWith('.jsonl')) {
         try {
           const fstat = fs.statSync(fp);
-          if (toLocalDate(fstat.mtime) >= targetDate) {
-            // For main session files, sessionId is the filename; for subagents, use parent session
-            const sid = sessionId || entry.name.replace('.jsonl', '');
-            results.push({ path: fp, sessionId: sid, project });
-          }
+          // Skip files not touched in 7 days — they can't have today's messages
+          if (fstat.mtimeMs < cutoff) continue;
+          const sid = sessionId || entry.name.replace('.jsonl', '');
+          results.push({ path: fp, sessionId: sid, project });
         } catch { /* skip */ }
       }
     }
@@ -390,10 +393,10 @@ function readSessionTokenUsage(dateStr) {
       try { msg = JSON.parse(line); } catch { continue; }
       if (!msg.message?.usage) continue;
 
-      // Filter by timestamp if available
+      // Filter by timestamp — convert UTC timestamp to local date for accurate comparison
       if (msg.timestamp) {
-        const msgDate = msg.timestamp.slice(0, 10);
-        if (msgDate < targetDate) continue;
+        const msgLocalDate = utcToLocalDate(msg.timestamp);
+        if (msgLocalDate !== targetDate) continue;
       }
 
       const u = msg.message.usage;

--- a/src/parser.js
+++ b/src/parser.js
@@ -297,6 +297,140 @@ function analyzeRouting(taskLog) {
   return routing;
 }
 
+/**
+ * Read actual token usage from Claude Code session JSONL files.
+ * Parses assistant messages with usage data, filtered by date.
+ * Returns { byModel: { [model]: { input, output, cacheRead, cacheWrite } }, bySession: { [sid]: ... } }
+ */
+function readSessionTokenUsage(dateStr) {
+  const projectsDir = path.join(CLAUDE_DIR, 'projects');
+  if (!fs.existsSync(projectsDir)) return { byModel: {}, bySession: {}, totalCost: 0 };
+
+  const now = new Date();
+  const targetDate = dateStr || `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  const byModel = {};
+  const bySession = {};
+  let totalCost = 0;
+
+  // Pricing per million tokens
+  const pricing = {
+    opus:   { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
+    sonnet: { input: 3.00,  output: 15.00, cacheRead: 0.30, cacheWrite: 3.75 },
+    haiku:  { input: 1.00,  output: 5.00,  cacheRead: 0.10, cacheWrite: 1.25 },
+  };
+
+  function getTier(model) {
+    if (!model) return 'opus';
+    if (model.includes('opus')) return 'opus';
+    if (model.includes('sonnet')) return 'sonnet';
+    if (model.includes('haiku')) return 'haiku';
+    return 'opus';
+  }
+
+  function calcCost(tier, tokens) {
+    const p = pricing[tier] || pricing.opus;
+    const m = 1_000_000;
+    return (tokens.input / m * p.input) +
+           (tokens.output / m * p.output) +
+           (tokens.cacheRead / m * p.cacheRead) +
+           (tokens.cacheWrite / m * p.cacheWrite);
+  }
+
+  // Convert Date to local YYYY-MM-DD string
+  function toLocalDate(d) {
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  }
+
+  // Recursively find all .jsonl files under projects dir, filtered by mtime
+  function findJsonlFiles(dir, project, sessionId) {
+    const results = [];
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return results; }
+    for (const entry of entries) {
+      const fp = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Derive session ID from UUID-shaped directory names
+        const sid = /^[0-9a-f]{8}-/.test(entry.name) ? entry.name : sessionId;
+        results.push(...findJsonlFiles(fp, project, sid));
+      } else if (entry.name.endsWith('.jsonl')) {
+        try {
+          const fstat = fs.statSync(fp);
+          if (toLocalDate(fstat.mtime) >= targetDate) {
+            // For main session files, sessionId is the filename; for subagents, use parent session
+            const sid = sessionId || entry.name.replace('.jsonl', '');
+            results.push({ path: fp, sessionId: sid, project });
+          }
+        } catch { /* skip */ }
+      }
+    }
+    return results;
+  }
+
+  let sessionFiles;
+  try {
+    sessionFiles = [];
+    for (const proj of fs.readdirSync(projectsDir)) {
+      const projDir = path.join(projectsDir, proj);
+      try {
+        if (!fs.statSync(projDir).isDirectory()) continue;
+      } catch { continue; }
+      sessionFiles.push(...findJsonlFiles(projDir, proj, null));
+    }
+  } catch {
+    return { byModel: {}, bySession: {}, totalCost: 0 };
+  }
+
+  for (const sf of sessionFiles) {
+    let content;
+    try { content = fs.readFileSync(sf.path, 'utf-8'); } catch { continue; }
+    const lines = content.trim().split('\n');
+
+    for (const line of lines) {
+      let msg;
+      try { msg = JSON.parse(line); } catch { continue; }
+      if (!msg.message?.usage) continue;
+
+      // Filter by timestamp if available
+      if (msg.timestamp) {
+        const msgDate = msg.timestamp.slice(0, 10);
+        if (msgDate < targetDate) continue;
+      }
+
+      const u = msg.message.usage;
+      const model = msg.message.model || 'unknown';
+      const tier = getTier(model);
+
+      const tokens = {
+        input: u.input_tokens || 0,
+        output: u.output_tokens || 0,
+        cacheRead: u.cache_read_input_tokens || 0,
+        cacheWrite: u.cache_creation_input_tokens || 0,
+      };
+
+      // Aggregate by model tier
+      if (!byModel[tier]) byModel[tier] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, calls: 0 };
+      byModel[tier].input += tokens.input;
+      byModel[tier].output += tokens.output;
+      byModel[tier].cacheRead += tokens.cacheRead;
+      byModel[tier].cacheWrite += tokens.cacheWrite;
+      byModel[tier].calls++;
+
+      const cost = calcCost(tier, tokens);
+      byModel[tier].cost += cost;
+      totalCost += cost;
+
+      // Aggregate by session
+      const sid = sf.sessionId;
+      if (!bySession[sid]) bySession[sid] = { cost: 0, calls: 0, models: {}, project: sf.project };
+      bySession[sid].cost += cost;
+      bySession[sid].calls++;
+      bySession[sid].models[tier] = (bySession[sid].models[tier] || 0) + 1;
+    }
+  }
+
+  return { byModel, bySession, totalCost };
+}
+
 module.exports = {
   CLAUDE_DIR,
   readStatsCache,
@@ -311,4 +445,5 @@ module.exports = {
   analyzeRouting,
   readRuns,
   readBenchmarkSummary,
+  readSessionTokenUsage,
 };

--- a/src/parser.js
+++ b/src/parser.js
@@ -138,7 +138,7 @@ function getProjects(history) {
 }
 
 /** Detect enabled MCP servers from settings */
-function getMcpServers(globalSettings, projectSettings) {
+function getMcpServers(globalSettings, projectSettings, projectPath) {
   const servers = new Set();
   const disabled = new Set();
 
@@ -146,6 +146,7 @@ function getMcpServers(globalSettings, projectSettings) {
     projectSettings.disabledMcpServers.forEach(s => disabled.add(s));
   }
 
+  // Read from ~/.claude/config.json (legacy location)
   const configPath = path.join(CLAUDE_DIR, 'config.json');
   if (fs.existsSync(configPath)) {
     try {
@@ -156,6 +157,36 @@ function getMcpServers(globalSettings, projectSettings) {
         });
       }
     } catch {}
+  }
+
+  // Read from ~/.mcp.json (global MCP config, newer format)
+  const globalMcpPath = path.join(os.homedir(), '.mcp.json');
+  if (fs.existsSync(globalMcpPath)) {
+    try {
+      const mcpConfig = JSON.parse(fs.readFileSync(globalMcpPath, 'utf-8'));
+      const mcpServers = mcpConfig.mcpServers || mcpConfig;
+      if (typeof mcpServers === 'object') {
+        Object.keys(mcpServers).forEach(s => {
+          if (!disabled.has(s)) servers.add(s);
+        });
+      }
+    } catch {}
+  }
+
+  // Read from <project>/.mcp.json (per-project MCP config)
+  if (projectPath) {
+    const projectMcpPath = path.join(projectPath, '.mcp.json');
+    if (fs.existsSync(projectMcpPath)) {
+      try {
+        const mcpConfig = JSON.parse(fs.readFileSync(projectMcpPath, 'utf-8'));
+        const mcpServers = mcpConfig.mcpServers || mcpConfig;
+        if (typeof mcpServers === 'object') {
+          Object.keys(mcpServers).forEach(s => {
+            if (!disabled.has(s)) servers.add(s);
+          });
+        }
+      } catch {}
+    }
   }
 
   return { enabled: [...servers], disabled: [...disabled] };
@@ -311,6 +342,8 @@ function readSessionTokenUsage(dateStr) {
   const byModel = {};
   const bySession = {};
   let totalCost = 0;
+  let latestTimestamp = '';
+  let latestSessionId = null;
 
   // Pricing per million tokens
   const pricing = {
@@ -422,6 +455,12 @@ function readSessionTokenUsage(dateStr) {
       byModel[tier].cost += cost;
       totalCost += cost;
 
+      // Track most recent session
+      if (msg.timestamp && msg.timestamp > latestTimestamp) {
+        latestTimestamp = msg.timestamp;
+        latestSessionId = sf.sessionId;
+      }
+
       // Aggregate by session
       const sid = sf.sessionId;
       if (!bySession[sid]) bySession[sid] = { cost: 0, calls: 0, models: {}, project: sf.project };
@@ -431,7 +470,14 @@ function readSessionTokenUsage(dateStr) {
     }
   }
 
-  return { byModel, bySession, totalCost };
+  // Determine the dominant model of the most recent session
+  let latestSessionModel = null;
+  if (latestSessionId && bySession[latestSessionId]) {
+    const models = bySession[latestSessionId].models;
+    latestSessionModel = Object.entries(models).sort((a, b) => b[1] - a[1])[0]?.[0] || null;
+  }
+
+  return { byModel, bySession, totalCost, latestSessionModel };
 }
 
 module.exports = {

--- a/src/router.js
+++ b/src/router.js
@@ -359,6 +359,7 @@ function recommendModel(classification, opts = {}) {
 
   return {
     model,
+    baseModel: base.model,
     model_floor: floor,
     fallbackChain: model === 'haiku' ? ['haiku', 'sonnet', 'opus']
       : model === 'sonnet' ? ['sonnet', 'opus']

--- a/src/router.js
+++ b/src/router.js
@@ -165,15 +165,7 @@ function classifyTask(task = '') {
 }
 
 /**
- * Routing preference tiers.
- * preference 0-25:  "max savings" -- push everything possible to haiku
- * preference 26-50: "cost-conscious" (default 35) -- sonnet-heavy, opus only for architecture/multi-file
- * preference 51-75: "balanced" -- opus for complex tasks
- * preference 76-100: "max quality" -- opus for anything medium+
- */
-
-/**
- * Get the base model recommendation (before preference adjustment).
+ * Get the base model recommendation (before floor adjustment).
  * Returns { model, reason } for each family×complexity.
  */
 function getBaseRecommendation(family, complexity) {
@@ -230,29 +222,38 @@ function upgrade(model) {
 const OPUS_FLOOR = new Set([TASK_FAMILIES.ARCHITECTURE]);
 
 /**
- * Recommend the optimal model tier based on classification and user preference.
+ * Recommend the optimal model tier based on classification and model floor.
+ *
+ * Model floor behaviour:
+ *   'haiku'  — start on haiku, only upgrade when the task genuinely needs more
+ *   'sonnet' — start on sonnet (default), upgrade to opus for complex/architecture
+ *   'opus'   — everything runs on opus, no downgrade
+ *
  * @param {object} classification -- from classifyTask()
- * @param {object} opts -- { preference?: number (0-100) }
+ * @param {object} opts -- { model_floor?: string, preference?: number (legacy) }
  */
 function recommendModel(classification, opts = {}) {
   const { family, complexity, customModel } = classification || {};
-  let preference = opts.preference;
 
-  // Load from config if not passed explicitly
-  if (preference == null) {
+  // Resolve model floor from opts or config
+  let floor = opts.model_floor;
+  let preference = opts.preference; // legacy compat
+  if (!floor) {
     try {
       const config = require('./config');
-      preference = config.read().routing_preference;
-    } catch {
-      preference = 35; // default: sonnet-heavy
-    }
+      const cfg = config.read();
+      floor = cfg.model_floor;
+      if (preference == null) preference = cfg.routing_preference;
+    } catch {}
   }
+  if (!MODEL_ORDER.includes(floor)) floor = 'sonnet';
+  if (preference == null) preference = 35;
 
   // If a custom rule supplied an explicit model override, honour it directly
   if (customModel && MODEL_ORDER.includes(customModel)) {
     return {
       model: customModel,
-      preference,
+      model_floor: floor,
       fallbackChain: customModel === 'haiku' ? ['haiku', 'sonnet', 'opus']
         : customModel === 'sonnet' ? ['sonnet', 'opus']
         : ['opus'],
@@ -275,7 +276,7 @@ function recommendModel(classification, opts = {}) {
   let model = base.model;
   const reasons = [base.reason];
 
-  // ── A/B experiment override: if an experiment is running for this family, use its assigned model ──
+  // ── A/B experiment override ──
   try {
     const { getActiveExperiment, assignModel } = require('./experiments');
     const exp = getActiveExperiment(family);
@@ -284,10 +285,9 @@ function recommendModel(classification, opts = {}) {
       if (experimentModel) {
         model = experimentModel;
         reasons.push(`[experiment] ${exp.id} (${exp.family}) -- assigned ${experimentModel} (${exp.count + 1}/${exp.target})`);
-        // Skip preference and learning adjustments when experiment is active
         return {
           model,
-          preference,
+          model_floor: floor,
           fallbackChain: model === 'haiku' ? ['haiku', 'sonnet', 'opus']
             : model === 'sonnet' ? ['sonnet', 'opus']
             : ['opus'],
@@ -297,41 +297,51 @@ function recommendModel(classification, opts = {}) {
         };
       }
     }
-  } catch {
-    // Experiments module not available -- skip
-  }
+  } catch {}
 
-  // Apply preference adjustment
-  if (preference <= 25 && !OPUS_FLOOR.has(family)) {
-    // Max savings: downgrade opus->sonnet, sonnet->haiku where safe
-    if (model === 'opus') {
-      model = 'sonnet';
-      reasons.push(`preference ${preference}/100 (max savings) -- downgraded from opus`);
-    } else if (model === 'sonnet' && complexity === 'low') {
-      model = 'haiku';
-      reasons.push(`preference ${preference}/100 (max savings) -- downgraded from sonnet`);
-    }
-  } else if (preference <= 50 && !OPUS_FLOOR.has(family)) {
-    // Cost-conscious (default): downgrade opus->sonnet for medium-complexity
-    if (model === 'opus' && complexity !== 'high') {
-      model = 'sonnet';
-      reasons.push(`preference ${preference}/100 (cost-conscious) -- sonnet sufficient for medium ${family}`);
-    } else if (model === 'opus' && complexity === 'high' && family === TASK_FAMILIES.DEBUG) {
-      // Even high-complexity debug can be sonnet at low preference
-      model = 'sonnet';
-      reasons.push(`preference ${preference}/100 (cost-conscious) -- trying sonnet for debug first`);
-    }
-  } else if (preference >= 76) {
-    // Max quality: upgrade sonnet->opus for medium+ complexity
-    if (model === 'sonnet' && complexity !== 'low') {
+  // ── Apply model floor ──
+  const floorIdx = MODEL_ORDER.indexOf(floor);
+  const modelIdx = MODEL_ORDER.indexOf(model);
+
+  if (floor === 'opus') {
+    // Opus-first: everything runs on opus, no routing
+    if (model !== 'opus') {
+      reasons.push(`floor=opus -- upgraded from ${model}`);
       model = 'opus';
-      reasons.push(`preference ${preference}/100 (max quality) -- upgraded to opus for ${complexity} ${family}`);
+    }
+  } else if (floor === 'haiku') {
+    // Haiku-first: aggressively downgrade unless task genuinely needs more
+    if (!OPUS_FLOOR.has(family)) {
+      if (model === 'opus' && complexity !== 'high') {
+        model = 'sonnet';
+        reasons.push('floor=haiku -- downgraded opus to sonnet (not high complexity)');
+      }
+      if (model === 'opus' && complexity === 'high' && family === TASK_FAMILIES.DEBUG) {
+        model = 'sonnet';
+        reasons.push('floor=haiku -- trying sonnet for debug first');
+      }
+      if (model === 'sonnet' && complexity === 'low') {
+        model = 'haiku';
+        reasons.push('floor=haiku -- downgraded to haiku (low complexity)');
+      }
+      // Medium-complexity sonnet tasks stay on sonnet even with haiku floor
+    }
+  } else {
+    // Sonnet-first (default): downgrade opus for non-high-complexity
+    if (!OPUS_FLOOR.has(family)) {
+      if (model === 'opus' && complexity !== 'high') {
+        model = 'sonnet';
+        reasons.push(`floor=sonnet -- sonnet sufficient for ${complexity} ${family}`);
+      }
+      if (model === 'opus' && complexity === 'high' && family === TASK_FAMILIES.DEBUG) {
+        model = 'sonnet';
+        reasons.push('floor=sonnet -- trying sonnet for debug first');
+      }
     }
   }
-  // 51-75: balanced -- use base recommendation as-is
 
   // ── Adaptive learning: adjust based on historical success rates ──
-  if (!OPUS_FLOOR.has(family)) {
+  if (!OPUS_FLOOR.has(family) && floor !== 'opus') {
     try {
       const { getAdjustment } = require('./learner');
       const adj = getAdjustment(family, model);
@@ -339,21 +349,17 @@ function recommendModel(classification, opts = {}) {
         if (adj.suggestion === 'upgrade' && adj.upgradeTo) {
           model = adj.upgradeTo;
           reasons.push(`[learned] ${adj.reason}`);
-        } else if (adj.suggestion === 'downgrade' && adj.downgradeTo && preference <= 50) {
-          // Only apply downgrades when user preference is cost-conscious
+        } else if (adj.suggestion === 'downgrade' && adj.downgradeTo && floor !== 'opus') {
           model = adj.downgradeTo;
           reasons.push(`[learned] ${adj.reason}`);
         }
-        // 'confirm' -- no change, but we could log it
       }
-    } catch {
-      // Learner not available -- skip
-    }
+    } catch {}
   }
 
   return {
     model,
-    preference,
+    model_floor: floor,
     fallbackChain: model === 'haiku' ? ['haiku', 'sonnet', 'opus']
       : model === 'sonnet' ? ['sonnet', 'opus']
       : ['opus'],

--- a/src/router.js
+++ b/src/router.js
@@ -147,9 +147,9 @@ function classifyTask(task = '') {
     reasons.push('question -- informational, no code changes');
   }
 
-  // Short prompts are usually simple -- but only for read-only/question tasks
+  // Short prompts are usually simple -- but only for read-only/question/unknown tasks
   // "Fix the critical auth bypass" is 5 words but not low complexity
-  const readOnlyFamilies = [TASK_FAMILIES.SEARCH_READ, TASK_FAMILIES.QUESTION, TASK_FAMILIES.COMMAND];
+  const readOnlyFamilies = [TASK_FAMILIES.SEARCH_READ, TASK_FAMILIES.QUESTION, TASK_FAMILIES.COMMAND, TASK_FAMILIES.UNKNOWN];
   if (words.length < 8 && complexity !== 'high' && readOnlyFamilies.includes(family)) {
     complexity = 'low';
     if (!reasons.length) reasons.push('short prompt -- likely simple task');
@@ -310,7 +310,7 @@ function recommendModel(classification, opts = {}) {
       model = 'opus';
     }
   } else if (floor === 'haiku') {
-    // Haiku-first: aggressively downgrade unless task genuinely needs more
+    // Haiku-first: start on haiku, only upgrade when task genuinely needs more
     if (!OPUS_FLOOR.has(family)) {
       if (model === 'opus' && complexity !== 'high') {
         model = 'sonnet';
@@ -324,7 +324,18 @@ function recommendModel(classification, opts = {}) {
         model = 'haiku';
         reasons.push('floor=haiku -- downgraded to haiku (low complexity)');
       }
-      // Medium-complexity sonnet tasks stay on sonnet even with haiku floor
+      // Unknown family: we have no reason to pay for sonnet when we can't classify the task
+      if (model === 'sonnet' && family === TASK_FAMILIES.UNKNOWN) {
+        model = 'haiku';
+        reasons.push('floor=haiku -- unclassified task, defaulting to haiku');
+      }
+      // Medium sonnet tasks that are code edits/reviews/plans stay on sonnet — they need it
+      // Everything else at medium goes to haiku
+      const keepSonnet = new Set([TASK_FAMILIES.CODE_EDIT, TASK_FAMILIES.REVIEW, TASK_FAMILIES.PLAN, TASK_FAMILIES.MULTI_FILE, TASK_FAMILIES.DEBUG]);
+      if (model === 'sonnet' && complexity === 'medium' && !keepSonnet.has(family)) {
+        model = 'haiku';
+        reasons.push(`floor=haiku -- ${family} at medium complexity, haiku sufficient`);
+      }
     }
   } else {
     // Sonnet-first (default): downgrade opus for non-high-complexity

--- a/src/server.js
+++ b/src/server.js
@@ -277,6 +277,8 @@ function buildDashboardData() {
     learning: getLearningStats(),
     // Token hog analysis
     tokenHogs: events.getTokenHogs(),
+    // User config (for dashboard UI controls)
+    config: config.read(),
   };
 }
 
@@ -302,6 +304,38 @@ const server = http.createServer((req, res) => {
       res.end(JSON.stringify({ error: err.message }));
     }
     return;
+  }
+
+  if (req.url === '/api/config') {
+    if (req.method === 'GET') {
+      const cfg = config.read();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(cfg));
+      return;
+    }
+    if (req.method === 'POST' || req.method === 'PUT') {
+      let body = '';
+      req.on('data', chunk => { body += chunk; });
+      req.on('end', () => {
+        try {
+          const updates = JSON.parse(body);
+          // Only allow known config keys
+          const allowed = new Set(Object.keys(config.DEFAULTS));
+          for (const [k, v] of Object.entries(updates)) {
+            if (!allowed.has(k)) continue;
+            if (k === 'model_floor' && !['haiku', 'sonnet', 'opus'].includes(v)) continue;
+            config.set(k, v);
+          }
+          config.clearCache();
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(config.read()));
+        } catch (err) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: err.message }));
+        }
+      });
+      return;
+    }
   }
 
   if (req.url === '/api/dashboard') {

--- a/src/server.js
+++ b/src/server.js
@@ -6,6 +6,7 @@ const calculator = require('./calculator');
 const { generateInsights } = require('./insights');
 const events = require('./events');
 const { getLearningStats } = require('./learner');
+const { calculateCounterfactual, calculateDailySavings } = require('./calculator');
 
 const config = require('./config');
 const PORT = process.env.PORT || config.read().dashboard_port || 6099;
@@ -284,6 +285,11 @@ function buildDashboardData() {
     learning: getLearningStats(),
     // Token hog analysis
     tokenHogs: events.getTokenHogs(),
+    // Savings: actual vs counterfactual (what-if-everything-was-opus)
+    savings: {
+      today: calculateCounterfactual(parser.readSessionTokenUsage()?.byModel),
+      daily: calculateDailySavings(stats?.dailyModelTokens, 14),
+    },
     // User config (for dashboard UI controls)
     config: config.read(),
   };

--- a/src/server.js
+++ b/src/server.js
@@ -161,20 +161,25 @@ function buildDashboardData() {
       timestamp: d.ts,
       project: d.project || 'unknown',
       model: d.recommended_model || 'sonnet',
+      baseModel: d.base_model || null,
+      modelFloor: d.model_floor || null,
       size: d.classification?.complexity === 'high' ? 'L' : d.classification?.complexity === 'low' ? 'S' : 'M',
       description: d.prompt_preview || d.recommended_reason || 'task',
     });
   }
-  // Also merge subagent_dispatch events as delegation entries (opus>sonnet etc)
+  // Also merge subagent_dispatch events as delegation entries
   const hookDispatches = recentEvents.filter(e => e.type === 'subagent_dispatch');
   for (const d of hookDispatches) {
     if (!d.ts || existingTimestamps.has(d.ts)) continue;
-    const src = d.parent_model || 'opus';
     const tgt = d.model_used || d.recommended_model || 'sonnet';
+    const src = d.parent_model || 'opus';
     taskLog.push({
       timestamp: d.ts,
       project: d.project || 'unknown',
-      model: src + '>' + tgt,
+      model: tgt,
+      baseModel: src,
+      modelFloor: null,
+      isSubagent: true,
       size: 'M',
       description: d.description || d.agent_type || 'subagent dispatch',
     });
@@ -214,6 +219,8 @@ function buildDashboardData() {
       timestamp: d.ts,
       project: d.project || 'unknown',
       model: d.recommended_model || 'sonnet',
+      baseModel: d.base_model || null,
+      modelFloor: d.model_floor || null,
       size: d.classification?.complexity === 'high' ? 'L' : d.classification?.complexity === 'low' ? 'S' : 'M',
       description: d.prompt_preview || d.recommended_reason || 'task',
     }));

--- a/src/server.js
+++ b/src/server.js
@@ -269,8 +269,10 @@ function buildDashboardData() {
       stats: routingStats,
       recent: recentEvents.slice(-100).reverse(),
     },
-    // Per-session cost tracking
+    // Per-session cost tracking (now using real token data from session files)
     sessionCosts: events.getSessionCosts(),
+    // Real token usage from Claude Code session files
+    todayTokenUsage: parser.readSessionTokenUsage(),
     // Adaptive learning stats
     learning: getLearningStats(),
     // Token hog analysis

--- a/src/server.js
+++ b/src/server.js
@@ -109,7 +109,7 @@ function buildDashboardData() {
   const mcpServers = {};
   for (const [name, info] of Object.entries(projects)) {
     const projectSettings = parser.readProjectSettings(info.path);
-    const servers = parser.getMcpServers(globalSettings, projectSettings);
+    const servers = parser.getMcpServers(globalSettings, projectSettings, info.path);
     mcpServers[name] = { ...servers, projectPath: info.path };
   }
 


### PR DESCRIPTION
## Summary
- Replaces the 0-100 `routing_preference` slider with a 3-option **model floor** selector: haiku-first, sonnet-first (default), opus-first
- Adds interactive selector card to the dashboard UI
- Adds `/api/config` GET/POST endpoint for dashboard config updates
- Backward-compatible: legacy `routing_preference` values auto-migrate to the nearest floor
- CLI `config model_floor haiku|sonnet|opus` support with validation

Closes #47

## Test plan
- [ ] `node bin/cli.js config` — shows `model_floor: "sonnet"` as default
- [ ] `node bin/cli.js config model_floor haiku` — sets floor, confirms
- [ ] `node bin/cli.js config model_floor invalid` — rejects with error
- [ ] Dashboard at :6099 shows 3-button selector below metrics
- [ ] Clicking a floor button updates config immediately (verify with `node bin/cli.js config`)
- [ ] Routing recommendations change based on floor (test with `node bin/cli.js run "search for files"` at each floor)
- [ ] Existing `routing_preference` users get auto-migrated on first read

🤖 Generated with [Claude Code](https://claude.com/claude-code)