### PR TITLE
Expand classifier question patterns to reduce unknown classifications

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -20,13 +20,28 @@ const TASK_FAMILIES = {
 
 const PATTERNS = {
   search: ['search', 'find', 'grep', 'look up', 'scan', 'where is', 'which file', 'locate', 'list', 'show me', 'what is', 'read', 'check', 'inspect', 'explore', 'browse'],
-  question: ['how do', 'how does', 'what does', 'why does', 'can you explain', 'tell me', 'what is the', 'does this', 'is there', 'help me understand', 'summarize', 'describe', 'explain'],
+  question: [
+    // Classic interrogatives
+    'how do', 'how does', 'how is', 'how are', 'how would',
+    'what does', 'what is the', 'what will', 'what would', 'what do you', 'what are',
+    'why does', 'why is', 'why are', 'why would',
+    'where do', 'where are', 'where is',
+    'when should', 'when do', 'when is',
+    'should we', 'should i', 'do we', 'do you', 'do i',
+    'are we', 'is this', 'is that', 'is there',
+    // Natural English opinion/conversational
+    'can you', 'could you', 'would you', 'will you',
+    'can you explain', 'tell me', 'help me understand',
+    'any thoughts', 'thoughts on', 'what do you think',
+    'does this', 'does that',
+    'summarize', 'describe', 'explain',
+  ],
   review: ['review', 'audit', 'compare', 'benchmark', 'analyze', 'assess', 'evaluate', 'check quality', 'code review', 'look over'],
   plan: ['plan', 'design', 'spec', 'roadmap', 'outline', 'strategy', 'approach', 'how should', 'what approach', 'propose'],
   architecture: ['architecture', 'system design', 'infrastructure', 'database schema', 'data model', 'migration strategy', 'scalability'],
-  edit: ['fix', 'edit', 'update', 'change', 'modify', 'implement', 'refactor', 'write', 'create', 'add', 'remove', 'delete', 'rename', 'move', 'replace'],
+  edit: ['fix', 'edit', 'update', 'change', 'modify', 'implement', 'refactor', 'write', 'create', 'add', 'remove', 'delete', 'rename', 'move', 'replace', 'make'],
   debug: ['bug', 'broken', 'debug', 'why does', 'failure', 'regression', 'error', 'crash', 'not working', 'fails', 'wrong', 'issue', 'problem', 'unexpected'],
-  command: ['run', 'execute', 'deploy', 'build', 'test', 'install', 'start', 'stop', 'restart', 'migrate'],
+  command: ['run', 'execute', 'deploy', 'build', 'test', 'install', 'start', 'stop', 'restart', 'migrate', 'merge', 'push', 'pull', 'close', 'open'],
   complex: ['multi-file', 'across', 'full app', 'entire', 'all files', 'whole codebase', 'comprehensive', 'complete', 'overhaul', 'rewrite', 'from scratch', 'system-wide'],
   simple: ['typo', 'rename', 'one line', 'small', 'quick', 'simple', 'just', 'only'],
 };


### PR DESCRIPTION
## Summary
- Expands question pattern set from 13 → 30 patterns to catch natural conversational English
- Adds `merge`, `push`, `pull`, `close`, `open` to command patterns
- Adds `make` to edit patterns

## Issues closed
Closes #58

## Test plan
- [ ] `node -e "const r=require('./src/router'); ['how is the active learning going','what will that command do','would you call this a skill','any thoughts on this','do we need to fix','where are the colors','should we merge'].forEach(p => console.log(r.classifyTask(p).family, '-', p))"` — all should return `question` not `unknown`
- [ ] `node -e "const r=require('./src/router'); console.log(r.classifyTask('merge the PR').family)"` — should return `command`
- [ ] Run a few conversational prompts in Claude Code — system-reminder should show `question (low)` not `unknown (medium)`

## Pass criteria
Conversational and opinion prompts classify as `question → haiku`, not `unknown → sonnet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)