### PR TITLE
Fix doctor/init hook test failing on Windows

### DIFF
--- a/src/init-command.js
+++ b/src/init-command.js
@@ -242,9 +242,10 @@ function runDiagnostics() {
     session_id: 'doctor-test',
   });
   try {
+    // Use `input` option instead of shell echo pipe — cross-platform safe (avoids cmd.exe on Windows)
     const result = execSync(
-      `echo '${testInput.replace(/'/g, "'\\''")}' | node "${hookScript}"`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }
+      `node "${hookScript}"`,
+      { encoding: 'utf-8', input: testInput, stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }
     );
     const parsed = JSON.parse(result);
     if (parsed.hookSpecificOutput && parsed.hookSpecificOutput.additionalContext) {
@@ -283,7 +284,10 @@ function runDiagnostics() {
   // 9. Verify settings.json hook path matches this repo
   total++;
   const hookCmd = settings.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command || '';
-  if (hookCmd.includes(hookScript)) {
+  // Normalize paths for comparison: strip quotes, normalize separators (Windows compat)
+  const hookCmdNorm = hookCmd.replace(/"/g, '').replace(/\\/g, '/');
+  const hookScriptNorm = hookScript.replace(/\\/g, '/');
+  if (hookCmdNorm.includes(hookScriptNorm)) {
     ok('Hook path in settings.json matches this repo');
     pass++;
   } else if (hookCmd.includes('hook-router.js')) {
@@ -321,9 +325,10 @@ function verifyHookWorks(repoDir) {
   });
 
   try {
+    // Use `input` option instead of shell echo pipe — cross-platform safe (avoids cmd.exe on Windows)
     const result = execSync(
-      `echo '${testInput.replace(/'/g, "'\\''")}' | node "${hookScript}"`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }
+      `node "${hookScript}"`,
+      { encoding: 'utf-8', input: testInput, stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }
     );
 
     // Should return JSON with hookSpecificOutput containing additionalContext


### PR DESCRIPTION
## Summary
- Replaces `echo '...' | node` shell pipe with `execSync`'s `input` option — cross-platform, no shell involved
- Fixes cosmetic path comparison failure in doctor check 9 on Windows (strip quotes, normalize separators)

## Issues closed
Closes #60

## Credit
Bug reported by external contributor with root cause and fix already identified.

## Test plan
- [ ] **Linux/macOS**: run `node bin/cli.js doctor` — all checks still pass (no regression)
- [ ] **Windows**: run `node bin/cli.js doctor` — check 7 (hook test) now passes
- [ ] **Windows**: check 9 (path match) shows correct match instead of false failure

## Pass criteria
Doctor reports 9/9 (or 10/10) on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)