### PR TITLE
feat: publish to npm — npx install support (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <p align="center">
+  <img src="https://img.shields.io/npm/v/claude-token-tracker" alt="npm version" />
   <img src="https://img.shields.io/badge/dependencies-0-brightgreen" alt="zero dependencies" />
   <img src="https://img.shields.io/badge/node-%3E%3D18-blue" alt="node >= 18" />
   <img src="https://img.shields.io/badge/license-MIT-orange" alt="MIT license" />
@@ -24,6 +25,14 @@
 
 ## Install
 
+**Option 1 — npx (no clone needed):**
+
+```bash
+npx claude-token-tracker init
+```
+
+**Option 2 — clone (easier to update):**
+
 ```bash
 git clone https://github.com/imwebdev/claude-token-tracker.git
 cd claude-token-tracker
@@ -38,19 +47,24 @@ No `npm install` needed. Zero dependencies. Seriously — zero.
 
 ## Update
 
-When a new version is released, run this from the repo folder:
+**npx users** — re-run init to pull the latest version:
+
+```bash
+npx claude-token-tracker@latest init
+```
+
+**Clone users** — run from the repo folder:
 
 ```bash
 cd claude-token-tracker
 node bin/cli.js update
 ```
 
-This pulls the latest code and restarts the dashboard. No reinstall needed.
-
 Verify everything is working:
 
 ```bash
-node bin/cli.js doctor
+npx claude-token-tracker doctor
+# or: node bin/cli.js doctor
 ```
 
 All checks should pass. If any fail, the output tells you exactly what to fix.

--- a/package.json
+++ b/package.json
@@ -1,19 +1,48 @@
 {
   "name": "claude-token-tracker",
   "version": "1.0.0",
-  "description": "Token usage dashboard and efficiency tracker for Claude Code",
+  "description": "Stop burning money on Claude Code. Routes each prompt to the cheapest capable model and shows you a real-time cost dashboard.",
   "main": "src/server.js",
   "bin": {
     "claude-tokens": "./bin/cli.js",
-    "token-coach": "./bin/cli.js"
+    "token-coach": "./bin/cli.js",
+    "claude-token-tracker": "./bin/cli.js"
   },
   "scripts": {
     "start": "node src/server.js",
     "dev": "node src/server.js"
   },
-  "keywords": ["claude", "claude-code", "tokens", "usage", "dashboard"],
+  "keywords": [
+    "claude",
+    "claude-code",
+    "anthropic",
+    "tokens",
+    "token-tracker",
+    "usage",
+    "dashboard",
+    "cost",
+    "model-routing",
+    "haiku",
+    "sonnet",
+    "opus"
+  ],
   "license": "MIT",
+  "homepage": "https://github.com/imwebdev/claude-token-tracker#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/imwebdev/claude-token-tracker.git"
+  },
+  "bugs": {
+    "url": "https://github.com/imwebdev/claude-token-tracker/issues"
+  },
   "engines": {
     "node": ">=18"
-  }
+  },
+  "files": [
+    "bin/",
+    "src/",
+    "public/",
+    "CLAUDE.md",
+    "CLAUDE-SNIPPET.md"
+  ]
 }

--- a/src/init-command.js
+++ b/src/init-command.js
@@ -483,8 +483,36 @@ function parsePort(args) {
   return null;
 }
 
+/**
+ * Return a stable on-disk path for the package.
+ * - Git clone  → the clone directory (has a .git folder)
+ * - Global npm → the global node_modules entry  (stable)
+ * - npx cache  → install globally then return global path
+ */
+function resolveStableRepoDir() {
+  const selfDir = path.resolve(path.join(__dirname, '..'));
+  // Already a git clone — path is stable
+  if (fs.existsSync(path.join(selfDir, '.git'))) return selfDir;
+  // Running from a global install (not an npx temp cache)
+  if (!selfDir.includes('_npx')) return selfDir;
+  // Running from npx temp cache — install globally so hooks survive cache cleans
+  info('Running via npx — installing globally for persistent hooks...');
+  try {
+    execSync('npm install -g claude-token-tracker', { encoding: 'utf-8', stdio: 'inherit' });
+    const globalRoot = execSync('npm root -g', { encoding: 'utf-8', stdio: 'pipe' }).trim();
+    const globalDir = path.join(globalRoot, 'claude-token-tracker');
+    if (fs.existsSync(globalDir)) {
+      ok(`Installed to ${globalDir}`);
+      return globalDir;
+    }
+  } catch (e) {
+    warn('Global install failed — hooks may break if npm cache is cleared. Run: npm install -g claude-token-tracker');
+  }
+  return selfDir; // best-effort fallback
+}
+
 function printInit(args = []) {
-  const repoDir = path.resolve(path.join(__dirname, '..'));
+  const repoDir = resolveStableRepoDir();
   const isDiagnose = args.includes('--doctor') || args.includes('doctor');
 
   if (isDiagnose) {
@@ -541,12 +569,19 @@ function printInit(args = []) {
   // Step 5: PM2 dashboard
   setupPm2(repoDir);
 
-  // Step 6: npm link (makes `claude-tokens` and `token-coach` available globally)
-  try {
-    execSync('npm link 2>/dev/null', { cwd: repoDir, encoding: 'utf-8', stdio: 'pipe' });
-    ok('Global commands installed (claude-tokens, token-coach)');
-  } catch {
-    info('Could not run npm link -- run with sudo or use: node bin/cli.js <command>');
+  // Step 6: Ensure global CLI commands are available
+  const isGitClone = fs.existsSync(path.join(repoDir, '.git'));
+  if (isGitClone) {
+    // Git clone: npm link wires up the bin entries from the local package
+    try {
+      execSync('npm link 2>/dev/null', { cwd: repoDir, encoding: 'utf-8', stdio: 'pipe' });
+      ok('Global commands installed: claude-tokens, token-coach, claude-token-tracker');
+    } catch {
+      info('Could not run npm link -- use: node bin/cli.js <command>');
+    }
+  } else {
+    // npm/npx install: bin entries are wired by npm automatically
+    ok('Global commands available: claude-tokens, token-coach, claude-token-tracker');
   }
 
   // Step 7: Validate router
@@ -568,7 +603,9 @@ function printInit(args = []) {
   console.log(`  ${yellow}Exit Claude Code completely and relaunch it.${reset}`);
   console.log(`  ${yellow}Hooks do not take effect until you restart.${reset}`);
   console.log('');
-  console.log(`  Run ${bold}node bin/cli.js doctor${reset} anytime to check health.\n`);
+  const isGitCloneCheck = fs.existsSync(path.join(repoDir, '.git'));
+  const doctorCmd = isGitCloneCheck ? 'node bin/cli.js doctor' : 'claude-tokens doctor';
+  console.log(`  Run ${bold}${doctorCmd}${reset} anytime to check health.\n`);
 }
 
 module.exports = { printInit, runDiagnostics };


### PR DESCRIPTION
## Summary
- Adds `claude-token-tracker` as a third bin entry so `npx claude-token-tracker init` works out of the box
- `resolveStableRepoDir()` in init-command.js detects when running from npx temp cache (`_npx` path) and auto-installs globally — ensures hook paths written to `~/.claude/settings.json` survive `npm cache clean`
- Replaces `npm link` step with smarter handling: link for git clones, passthrough for npm installs
- `package.json`: added `files` array (only ships src/bin/public), `repository`/`bugs`/`homepage` fields, richer keywords, better description
- README: npx as the primary install option, update instructions for npx users, npm version badge

## Test plan
- [ ] `npm pack --dry-run` — verify only src/bin/public/CLAUDE.md included
- [ ] `node bin/cli.js init` still works from git clone (doctor passes)
- [ ] After npm publish: `npx claude-token-tracker init` completes without error
- [ ] After npx install: `claude-tokens doctor` passes

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)