### PR TITLE
feat(#81): PreToolUse read-deduper hook — hard-block redundant file reads

### DIFF
--- a/bin/hook-router.js
+++ b/bin/hook-router.js
@@ -20,6 +20,8 @@ const path = require('path');
 const ROOT = path.join(__dirname, '..');
 const router = require(path.join(ROOT, 'src', 'router'));
 const events = require(path.join(ROOT, 'src', 'events'));
+const readCache = require(path.join(ROOT, 'src', 'read-cache'));
+const config = require(path.join(ROOT, 'src', 'config'));
 
 function readStdin() {
   return new Promise((resolve) => {
@@ -281,6 +283,44 @@ function handleUserPromptSubmit(input) {
 function handlePreToolUse(input) {
   const toolName = input.tool_name || '';
   const toolInput = input.tool_input || {};
+  const sessionId = input.session_id;
+
+  // ── Read deduper: hard-block redundant reads in the same session ──
+  if (toolName === 'Read') {
+    let cfg = {};
+    try { cfg = config.read(); } catch {}
+    if (cfg.read_dedupe !== false) {
+      const absPath = toolInput.file_path;
+      const hasRange = toolInput.offset != null || toolInput.limit != null;
+      // Only dedupe full-file reads. If Claude asks for a specific range, let it through —
+      // the cached summary can't substitute for a targeted slice.
+      if (absPath && !hasRange) {
+        try { readCache.prune(); } catch {}
+        const hit = readCache.lookup(sessionId, absPath);
+        if (hit) {
+          events.logEvent('read_deduped', {
+            session_id: sessionId,
+            project: getProject(input),
+            file_path: absPath,
+            line_count: hit.lineCount,
+            first_read_at: hit.firstRead,
+          });
+          const reason = readCache.summarize(absPath, hit);
+          return {
+            hookSpecificOutput: {
+              hookEventName: 'PreToolUse',
+              permissionDecision: 'deny',
+              permissionDecisionReason: reason,
+              additionalContext: `[token-coach] ${reason} If you truly need a fresh read (file may have changed), use an explicit offset/limit range.`,
+            },
+          };
+        }
+        // Cache miss — record the read so future duplicates are caught.
+        try { readCache.record(sessionId, absPath); } catch {}
+      }
+    }
+    // Fall through (no other Read-specific behavior).
+  }
 
   if (toolName === 'Agent') {
     const model = toolInput.model || 'opus';
@@ -360,6 +400,21 @@ function handlePreToolUse(input) {
     });
   }
 
+  return null;
+}
+
+function handlePostToolUse(input) {
+  const toolName = input.tool_name || '';
+  const toolInput = input.tool_input || {};
+  const sessionId = input.session_id;
+
+  // Invalidate read cache when a file is modified
+  if (toolName === 'Write' || toolName === 'Edit' || toolName === 'MultiEdit' || toolName === 'NotebookEdit') {
+    const fp = toolInput.file_path || toolInput.notebook_path;
+    if (fp && sessionId) {
+      try { readCache.invalidate(sessionId, fp); } catch {}
+    }
+  }
   return null;
 }
 
@@ -483,6 +538,9 @@ async function main() {
       break;
     case 'PreToolUse':
       output = handlePreToolUse(input);
+      break;
+    case 'PostToolUse':
+      output = handlePostToolUse(input);
       break;
     case 'SubagentStop':
       output = handleSubagentStop(input);

--- a/src/config.js
+++ b/src/config.js
@@ -36,6 +36,11 @@ const DEFAULTS = {
   // Fraction of turns to ask for feedback (0.0–1.0). Default: ask 1 in 10.
   // High-confidence classifications (≥0.7) skip regardless of this setting.
   feedback_loop_sample_rate: 0.1,
+
+  // Read deduper: hard-block redundant Read tool calls in the same session
+  // via PreToolUse permissionDecision: "deny". Claude sees a summary pointer
+  // instead of re-reading the full file. Set to false to disable.
+  read_dedupe: true,
 };
 
 let _cache = null;

--- a/src/init-command.js
+++ b/src/init-command.js
@@ -18,6 +18,7 @@ const HOOK_SCRIPT = path.resolve(path.join(__dirname, '..', 'bin', 'hook-router.
 const HOOK_EVENTS = [
   'UserPromptSubmit',
   'PreToolUse',
+  'PostToolUse',
   'Stop',
   'StopFailure',
   'SessionStart',

--- a/src/read-cache.js
+++ b/src/read-cache.js
@@ -1,0 +1,157 @@
+/**
+ * Per-session Read cache — tracks which files have already been read so the
+ * PreToolUse hook can hard-block redundant Read tool calls via
+ * permissionDecision: "deny".
+ *
+ * Storage: one JSON file per session at
+ *   ~/.token-coach/read-cache/<session_id>.json
+ * Hooks are stateless processes; the file backing survives across invocations.
+ *
+ * Cache entry shape:
+ *   {
+ *     <absPath>: {
+ *       mtime:     number   // file mtimeMs at first read
+ *       size:      number   // file size in bytes at first read
+ *       lineCount: number   // approximate lines
+ *       firstRead: string   // ISO timestamp
+ *       range:     { offset?, limit? } | null
+ *     },
+ *     ...
+ *   }
+ */
+const fs = require('fs');
+const path = require('path');
+const dataHome = require('./data-home');
+
+const SESSION_TTL_MS = 60 * 60 * 1000; // 1h
+
+function cacheDir() {
+  return path.join(dataHome.getDataHome(), 'read-cache');
+}
+
+function cacheFile(sessionId) {
+  const safe = String(sessionId || 'unknown').replace(/[^a-zA-Z0-9_.-]/g, '_');
+  return path.join(cacheDir(), `${safe}.json`);
+}
+
+function ensure() {
+  fs.mkdirSync(cacheDir(), { recursive: true });
+}
+
+function loadSession(sessionId) {
+  const fp = cacheFile(sessionId);
+  if (!fs.existsSync(fp)) return {};
+  try { return JSON.parse(fs.readFileSync(fp, 'utf-8')); }
+  catch { return {}; }
+}
+
+function saveSession(sessionId, state) {
+  ensure();
+  fs.writeFileSync(cacheFile(sessionId), JSON.stringify(state));
+}
+
+function statFile(absPath) {
+  try {
+    const st = fs.statSync(absPath);
+    if (!st.isFile()) return null;
+    return { mtime: st.mtimeMs, size: st.size };
+  } catch { return null; }
+}
+
+function countLines(absPath, maxBytes = 2 * 1024 * 1024) {
+  try {
+    const st = fs.statSync(absPath);
+    if (st.size > maxBytes) {
+      // Estimate rather than reading very large files
+      return Math.ceil(st.size / 80);
+    }
+    const buf = fs.readFileSync(absPath);
+    let n = 0;
+    for (let i = 0; i < buf.length; i++) if (buf[i] === 10) n++;
+    return n + 1;
+  } catch { return 0; }
+}
+
+/**
+ * Check whether a file has already been read in this session.
+ * Returns the cached entry if the file has not changed on disk; null otherwise.
+ */
+function lookup(sessionId, absPath) {
+  if (!sessionId || !absPath) return null;
+  const state = loadSession(sessionId);
+  const entry = state[absPath];
+  if (!entry) return null;
+  const st = statFile(absPath);
+  if (!st) return null;
+  // Invalidate if file changed since first read
+  if (st.mtime !== entry.mtime || st.size !== entry.size) return null;
+  return entry;
+}
+
+/**
+ * Record that a file was read by the current session.
+ */
+function record(sessionId, absPath, extra = {}) {
+  if (!sessionId || !absPath) return null;
+  const st = statFile(absPath);
+  if (!st) return null;
+  const state = loadSession(sessionId);
+  state[absPath] = {
+    mtime: st.mtime,
+    size: st.size,
+    lineCount: countLines(absPath),
+    firstRead: new Date().toISOString(),
+    range: extra.range || null,
+  };
+  saveSession(sessionId, state);
+  return state[absPath];
+}
+
+/**
+ * Invalidate cache entry for a file (after a Write/Edit).
+ */
+function invalidate(sessionId, absPath) {
+  if (!sessionId || !absPath) return false;
+  const state = loadSession(sessionId);
+  if (!state[absPath]) return false;
+  delete state[absPath];
+  saveSession(sessionId, state);
+  return true;
+}
+
+/**
+ * Prune session files older than SESSION_TTL_MS. Safe to call from any hook.
+ */
+function prune() {
+  try {
+    ensure();
+    const now = Date.now();
+    for (const f of fs.readdirSync(cacheDir())) {
+      if (!f.endsWith('.json')) continue;
+      const fp = path.join(cacheDir(), f);
+      try {
+        const st = fs.statSync(fp);
+        if (now - st.mtimeMs > SESSION_TTL_MS) fs.unlinkSync(fp);
+      } catch {}
+    }
+  } catch {}
+}
+
+/**
+ * Produce a short, Claude-readable summary for the deny message.
+ */
+function summarize(absPath, entry) {
+  const rel = path.basename(absPath);
+  const age = Math.round((Date.now() - new Date(entry.firstRead).getTime()) / 1000);
+  const ageStr = age < 60 ? `${age}s ago` : `${Math.round(age / 60)}m ago`;
+  return `Already read ${rel} (${entry.lineCount} lines) ${ageStr} this session. File unchanged on disk. Use the prior content instead of re-reading.`;
+}
+
+module.exports = {
+  lookup,
+  record,
+  invalidate,
+  prune,
+  summarize,
+  _internal: { cacheFile, cacheDir, statFile, countLines },
+};

--- a/test/read-cache.test.js
+++ b/test/read-cache.test.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for src/read-cache.js
+ * Run: node test/read-cache.test.js
+ */
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Redirect TOKEN_COACH_HOME to a temp dir before loading the module
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-read-cache-'));
+process.env.TOKEN_COACH_HOME = TMP;
+
+const readCache = require('../src/read-cache');
+
+const results = [];
+function test(name, fn) {
+  try {
+    fn();
+    results.push({ name, ok: true });
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    results.push({ name, ok: false, err });
+    console.log(`  FAIL ${name}`);
+    console.log(`       ${err.message}`);
+  }
+}
+
+function makeFile(contents = 'line1\nline2\nline3\n') {
+  const fp = path.join(TMP, `sample-${Date.now()}-${Math.random()}.txt`);
+  fs.writeFileSync(fp, contents);
+  return fp;
+}
+
+console.log('read-cache tests');
+
+test('lookup returns null for uncached file', () => {
+  const fp = makeFile();
+  assert.strictEqual(readCache.lookup('s1', fp), null);
+});
+
+test('record + lookup returns entry with lineCount', () => {
+  const fp = makeFile('a\nb\nc\nd\n');
+  readCache.record('s2', fp);
+  const hit = readCache.lookup('s2', fp);
+  assert.ok(hit, 'expected cache hit after record');
+  assert.strictEqual(hit.lineCount, 5); // 4 newlines + 1
+  assert.ok(hit.mtime > 0);
+  assert.ok(hit.firstRead);
+});
+
+test('lookup invalidates when file mtime changes', () => {
+  const fp = makeFile('original\n');
+  readCache.record('s3', fp);
+  // Wait enough for mtime granularity, then rewrite
+  const future = new Date(Date.now() + 2000);
+  fs.utimesSync(fp, future, future);
+  assert.strictEqual(readCache.lookup('s3', fp), null, 'mtime change should invalidate');
+});
+
+test('invalidate() removes entry', () => {
+  const fp = makeFile();
+  readCache.record('s4', fp);
+  assert.ok(readCache.lookup('s4', fp));
+  const removed = readCache.invalidate('s4', fp);
+  assert.strictEqual(removed, true);
+  assert.strictEqual(readCache.lookup('s4', fp), null);
+});
+
+test('separate sessions do not share cache', () => {
+  const fp = makeFile();
+  readCache.record('sA', fp);
+  assert.ok(readCache.lookup('sA', fp));
+  assert.strictEqual(readCache.lookup('sB', fp), null);
+});
+
+test('summarize produces a non-empty human-readable string', () => {
+  const fp = makeFile('x\ny\n');
+  readCache.record('s5', fp);
+  const hit = readCache.lookup('s5', fp);
+  const s = readCache.summarize(fp, hit);
+  assert.ok(typeof s === 'string' && s.length > 20);
+  assert.ok(s.includes('Already read'));
+});
+
+test('prune removes old session files', () => {
+  const fp = makeFile();
+  readCache.record('s-old', fp);
+  const cacheFile = readCache._internal.cacheFile('s-old');
+  // Age it past the 1h TTL
+  const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+  fs.utimesSync(cacheFile, old, old);
+  readCache.prune();
+  assert.strictEqual(fs.existsSync(cacheFile), false);
+});
+
+test('missing sessionId or path returns gracefully', () => {
+  assert.strictEqual(readCache.lookup(null, '/tmp/x'), null);
+  assert.strictEqual(readCache.lookup('s', null), null);
+  assert.strictEqual(readCache.record(null, '/tmp/x'), null);
+  assert.strictEqual(readCache.invalidate(null, null), false);
+});
+
+test('lookup returns null for non-existent file', () => {
+  readCache.record('s6', path.join(TMP, 'nope-does-not-exist.txt'));
+  assert.strictEqual(readCache.lookup('s6', path.join(TMP, 'nope-does-not-exist.txt')), null);
+});
+
+// ── Summary ────────────────────────────────────────────────
+const passed = results.filter(r => r.ok).length;
+const failed = results.length - passed;
+console.log(`\n${passed}/${results.length} passed, ${failed} failed`);
+
+// Cleanup
+try { fs.rmSync(TMP, { recursive: true, force: true }); } catch {}
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #81.

## Summary
- Hard-blocks duplicate full-file `Read` tool calls in the same Claude Code session via `PreToolUse` hook with `permissionDecision: "deny"` + context-injected summary
- Per-session cache at `~/.token-coach/read-cache/<session>.json` keyed on absolute path; invalidated by file mtime/size change on disk or by `Write`/`Edit`/`MultiEdit`/`NotebookEdit`
- Range reads (`offset`/`limit`) bypass dedupe — targeted slices are legitimate
- `read_dedupe: true` config default (opt-out via `~/.token-coach/config.json`)
- Events logged as `read_deduped` — feeds the savings chart in #83

## Mechanism
OpenWolf uses stderr warnings and hopes Claude voluntarily skips re-reads. This PR uses the spec-supported `hookSpecificOutput.permissionDecision: "deny"` field so the skip is mechanical, not advisory.

```json
{
  "hookSpecificOutput": {
    "hookEventName": "PreToolUse",
    "permissionDecision": "deny",
    "permissionDecisionReason": "Already read foo.ts (248 lines) 12s ago this session. File unchanged on disk. Use the prior content instead of re-reading.",
    "additionalContext": "[token-coach] ... If you truly need a fresh read (file may have changed), use an explicit offset/limit range."
  }
}
```

## Files changed
- `src/read-cache.js` — new module (lookup, record, invalidate, prune, summarize)
- `bin/hook-router.js` — Read dedupe path in `handlePreToolUse`; new `handlePostToolUse` for cache invalidation; `PostToolUse` wired into the main switch
- `src/init-command.js` — `PostToolUse` added to `HOOK_EVENTS` so `doctor` verifies registration and `init` installs on existing users via re-run
- `src/config.js` — `read_dedupe: true` default
- `test/read-cache.test.js` — 9 unit tests, all passing

## Test plan
- [x] `node test/read-cache.test.js` → 9/9 pass
- [x] `node test/classifier-benchmark.js` → 204/206 (no regression from main)
- [x] `node bin/cli.js doctor` → 10/10 pass after re-running `init`
- [x] End-to-end hook simulation: first read returns empty (allowed + cached), second identical read returns deny JSON, `Write` invalidates, third read returns empty (allowed again)
- [ ] Manual verification on a real Claude Code session — **restart Claude Code, read the same file twice, verify the second read is blocked with the deny reason**

## Pass criteria (from #81)
- [x] Read the same file twice → second is blocked with a clear message
- [x] Write/Edit invalidates cache → next read succeeds
- [x] Opt-out config disables cleanly (`read_dedupe: false`)
- [x] `doctor` catches misconfiguration
- [ ] Dashboard counter for `read_deduped` events — handled in #83

## Caveats
- Cache is per-session-id. If Claude Code ever changes how `session_id` is emitted (e.g., regenerates mid-session), the cache will effectively reset. This is acceptable for v1.
- `summarize()` returns a pointer + metadata, not a real content summary. Follow-up can inject the first-N-lines or a structural hash.
- No cross-session cache in v1 (hooks are stateless, each session starts empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)