### PR TITLE
feat(#82): install-date marker + real daily cost series

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -224,6 +224,56 @@ function calculateDailySavings(dailyModelTokens, days = 14) {
   });
 }
 
+/**
+ * Build a first-class per-day cost series from stats-cache dailyModelTokens.
+ * Uses real token counts (not hardcoded per-call estimates) and blended
+ * input/output/cache pricing per model tier.
+ *
+ * Each entry: { date, cost, tokens, byModel: { opus: { tokens, cost }, ... } }
+ *
+ * @param {Array} dailyModelTokens — [{ date, tokensByModel: { "<modelId>": N } }]
+ * @param {number} days — tail window size (default 30)
+ */
+function buildDailyCostSeries(dailyModelTokens, days = 30) {
+  if (!Array.isArray(dailyModelTokens) || dailyModelTokens.length === 0) return [];
+
+  // Blended cost-per-token derived from typical Claude Code usage mix:
+  // ~60% cache-read, ~30% input, ~8% output, ~2% cache-write.
+  function blendedRate(modelId) {
+    const p = getModelPrice(modelId);
+    return (p.input * 0.30 + p.output * 0.08 + p.cacheRead * 0.60 + p.cacheWrite * 0.02);
+  }
+
+  const m = 1_000_000;
+  return dailyModelTokens.slice(-days).map(d => {
+    let totalCost = 0;
+    let totalTokens = 0;
+    const byModel = {};
+
+    for (const [modelId, tokens] of Object.entries(d.tokensByModel || {})) {
+      const tier = getModelTier(modelId);
+      const cost = (tokens / m) * blendedRate(modelId);
+      totalCost += cost;
+      totalTokens += tokens;
+      if (!byModel[tier]) byModel[tier] = { tokens: 0, cost: 0 };
+      byModel[tier].tokens += tokens;
+      byModel[tier].cost += cost;
+    }
+
+    // Round for JSON compactness
+    for (const tier of Object.keys(byModel)) {
+      byModel[tier].cost = Math.round(byModel[tier].cost * 10000) / 10000;
+    }
+
+    return {
+      date: d.date,
+      cost: Math.round(totalCost * 10000) / 10000,
+      tokens: totalTokens,
+      byModel,
+    };
+  });
+}
+
 module.exports = {
   PRICING,
   getModelPrice,
@@ -234,4 +284,5 @@ module.exports = {
   estimateSessionCost,
   calculateCounterfactual,
   calculateDailySavings,
+  buildDailyCostSeries,
 };

--- a/src/init-command.js
+++ b/src/init-command.js
@@ -8,6 +8,7 @@ const os = require('os');
 const { execSync } = require('child_process');
 const dataHome = require('./data-home');
 const config = require('./config');
+const installMeta = require('./install-meta');
 const { classifyTask, recommendModel } = require('./router');
 
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
@@ -510,6 +511,14 @@ function printInit(args = []) {
   // Step 2: Create data directories
   dataHome.ensureDataHome();
   ok(`Data directory: ${dataHome.getDataHome()}`);
+
+  // Step 2a: Record install timestamp (idempotent — only writes on first run)
+  const installInfo = installMeta.recordInstall();
+  if (installInfo.created) {
+    ok(`Install date recorded: ${installInfo.installed_at}`);
+  } else {
+    info(`Install date: ${installInfo.installed_at} (v${installInfo.version})`);
+  }
 
   // Step 3: Write default config if none exists
   const cfg = config.read();

--- a/src/install-meta.js
+++ b/src/install-meta.js
@@ -1,0 +1,57 @@
+/**
+ * Install metadata — the "installed_at" timestamp is the anchor point for
+ * "cost since install" visualizations (see #83). Written idempotently on
+ * first init; never overwritten, so the date stays accurate across upgrades.
+ *
+ * File: ~/.token-coach/install.json
+ *   { installed_at: ISO timestamp, version: semver from package.json }
+ */
+const fs = require('fs');
+const path = require('path');
+const dataHome = require('./data-home');
+
+function installPath() {
+  return dataHome.getPath('install.json');
+}
+
+function readPackageVersion() {
+  try {
+    const pkg = require(path.join(__dirname, '..', 'package.json'));
+    return pkg.version || 'unknown';
+  } catch { return 'unknown'; }
+}
+
+/**
+ * Record the install timestamp if not already present.
+ * Idempotent: never overwrites an existing marker.
+ *
+ * @returns {{ installed_at: string, version: string, created: boolean }}
+ */
+function recordInstall() {
+  dataHome.ensureDataHome();
+  const fp = installPath();
+  if (fs.existsSync(fp)) {
+    try {
+      const existing = JSON.parse(fs.readFileSync(fp, 'utf-8'));
+      if (existing && existing.installed_at) {
+        return { ...existing, created: false };
+      }
+    } catch { /* fall through and rewrite */ }
+  }
+  const meta = {
+    installed_at: new Date().toISOString(),
+    version: readPackageVersion(),
+  };
+  fs.writeFileSync(fp, JSON.stringify(meta, null, 2) + '\n');
+  return { ...meta, created: true };
+}
+
+/** Read install metadata, or null if not yet recorded. */
+function readInstall() {
+  const fp = installPath();
+  if (!fs.existsSync(fp)) return null;
+  try { return JSON.parse(fs.readFileSync(fp, 'utf-8')); }
+  catch { return null; }
+}
+
+module.exports = { recordInstall, readInstall, installPath };

--- a/src/server.js
+++ b/src/server.js
@@ -6,7 +6,8 @@ const calculator = require('./calculator');
 const { generateInsights } = require('./insights');
 const events = require('./events');
 const { getLearningStats } = require('./learner');
-const { calculateCounterfactual, calculateDailySavings } = require('./calculator');
+const { calculateCounterfactual, calculateDailySavings, buildDailyCostSeries } = require('./calculator');
+const installMeta = require('./install-meta');
 
 const config = require('./config');
 const os = require('os');
@@ -452,6 +453,11 @@ function buildDashboardData() {
     feedbackStats: events.getFeedbackStats(),
     // Per-day routing breakdown (last 30 days)
     dailyBreakdown: dailyBreakdownArr,
+    // Per-day cost series built from real stats-cache token counts (last 30 days).
+    // [{ date, cost, tokens, byModel: { opus: { tokens, cost }, sonnet: ..., haiku: ... } }]
+    dailyCostSeries: buildDailyCostSeries(stats?.dailyModelTokens, 30),
+    // Install metadata — anchor point for "cost since install" visualizations
+    installDate: installMeta.readInstall()?.installed_at || null,
     // Efficiency analysis / grading
     analysis,
   };

--- a/test/install-cost.test.js
+++ b/test/install-cost.test.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Tests for install-meta (#82 install-date marker) and calculator.buildDailyCostSeries.
+ * Run: node test/install-cost.test.js
+ */
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-install-cost-'));
+process.env.TOKEN_COACH_HOME = TMP;
+
+// Lazy-load modules so TOKEN_COACH_HOME is respected
+const installMeta = require('../src/install-meta');
+const calculator = require('../src/calculator');
+
+const results = [];
+function test(name, fn) {
+  try {
+    fn();
+    results.push({ name, ok: true });
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    results.push({ name, ok: false, err });
+    console.log(`  FAIL ${name}`);
+    console.log(`       ${err.message}`);
+  }
+}
+
+console.log('install-meta tests');
+
+test('first recordInstall creates file with created=true', () => {
+  const info = installMeta.recordInstall();
+  assert.strictEqual(info.created, true);
+  assert.ok(info.installed_at);
+  assert.ok(Number.isNaN(Date.parse(info.installed_at)) === false, 'installed_at must be valid ISO');
+  assert.ok(info.version);
+  assert.ok(fs.existsSync(installMeta.installPath()));
+});
+
+test('second recordInstall returns same timestamp with created=false (idempotent)', () => {
+  const first = installMeta.readInstall();
+  const second = installMeta.recordInstall();
+  assert.strictEqual(second.created, false);
+  assert.strictEqual(second.installed_at, first.installed_at);
+});
+
+test('readInstall returns null when file missing', () => {
+  fs.rmSync(installMeta.installPath(), { force: true });
+  assert.strictEqual(installMeta.readInstall(), null);
+});
+
+test('readInstall recovers gracefully from corrupt JSON', () => {
+  fs.writeFileSync(installMeta.installPath(), '{ not valid json');
+  assert.strictEqual(installMeta.readInstall(), null);
+  // Corruption is replaced on next recordInstall
+  const info = installMeta.recordInstall();
+  assert.ok(info.installed_at);
+});
+
+console.log('\nbuildDailyCostSeries tests');
+
+test('empty input returns empty array', () => {
+  assert.deepStrictEqual(calculator.buildDailyCostSeries([]), []);
+  assert.deepStrictEqual(calculator.buildDailyCostSeries(null), []);
+  assert.deepStrictEqual(calculator.buildDailyCostSeries(undefined), []);
+});
+
+test('basic shape: date, cost, tokens, byModel', () => {
+  const input = [
+    {
+      date: '2026-04-10',
+      tokensByModel: {
+        'claude-opus-4-6': 1_000_000,
+        'claude-sonnet-4-6': 2_000_000,
+      },
+    },
+  ];
+  const series = calculator.buildDailyCostSeries(input);
+  assert.strictEqual(series.length, 1);
+  const d = series[0];
+  assert.strictEqual(d.date, '2026-04-10');
+  assert.strictEqual(d.tokens, 3_000_000);
+  assert.ok(d.cost > 0);
+  assert.ok(d.byModel.opus);
+  assert.ok(d.byModel.sonnet);
+  assert.strictEqual(d.byModel.opus.tokens, 1_000_000);
+  assert.strictEqual(d.byModel.sonnet.tokens, 2_000_000);
+  // Opus is more expensive per-token → opus cost > sonnet cost despite fewer tokens? no — sonnet has 2x tokens
+  assert.ok(d.byModel.opus.cost > 0);
+  assert.ok(d.byModel.sonnet.cost > 0);
+});
+
+test('days parameter trims to last N entries', () => {
+  const input = Array.from({ length: 10 }, (_, i) => ({
+    date: `2026-04-${String(i + 1).padStart(2, '0')}`,
+    tokensByModel: { 'claude-haiku-4-5-20251001': 500_000 },
+  }));
+  const series = calculator.buildDailyCostSeries(input, 3);
+  assert.strictEqual(series.length, 3);
+  assert.strictEqual(series[0].date, '2026-04-08');
+  assert.strictEqual(series[2].date, '2026-04-10');
+});
+
+test('cost math: opus tokens should cost more than same haiku tokens', () => {
+  const opusOnly = calculator.buildDailyCostSeries([
+    { date: '2026-04-10', tokensByModel: { 'claude-opus-4-6': 1_000_000 } },
+  ]);
+  const haikuOnly = calculator.buildDailyCostSeries([
+    { date: '2026-04-10', tokensByModel: { 'claude-haiku-4-5-20251001': 1_000_000 } },
+  ]);
+  assert.ok(opusOnly[0].cost > haikuOnly[0].cost,
+    `opus cost (${opusOnly[0].cost}) should exceed haiku cost (${haikuOnly[0].cost}) for same tokens`);
+});
+
+test('unknown model tier falls through gracefully', () => {
+  const series = calculator.buildDailyCostSeries([
+    { date: '2026-04-10', tokensByModel: { 'mystery-model': 100_000 } },
+  ]);
+  assert.strictEqual(series.length, 1);
+  assert.ok(series[0].cost >= 0); // defaults to opus pricing in getModelPrice
+});
+
+// ── Summary ────────────────────────────────────────────────
+const passed = results.filter(r => r.ok).length;
+const failed = results.length - passed;
+console.log(`\n${passed}/${results.length} passed, ${failed} failed`);
+
+try { fs.rmSync(TMP, { recursive: true, force: true }); } catch {}
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #82.

## Summary
- Records install timestamp idempotently at \`~/.token-coach/install.json\` — anchor point for "cost since install" chart in #83
- Adds \`dailyCostSeries\` to \`/api/dashboard\`: per-day cost built from real \`~/.claude/stats-cache.json\` token counts with blended model pricing (replaces hardcoded per-call guesses)
- Adds \`installDate\` to \`/api/dashboard\`

## Why this shape
\`stats-cache.json\` exposes \`dailyModelTokens\` as \`{ date, tokensByModel: { <modelId>: totalTokens } }\` — per-day totals only, no input/output/cache split. For a chart this is enough: a blended cost-per-token (~60% cache-read, ~30% input, ~8% output, ~2% cache-write) yields stable daily numbers. Exact splits only exist for today in live JSONL, and the dashboard already shows today separately via \`readSessionTokenUsage()\`.

## Smoke test output (live stats-cache)
\`\`\`
last 5 days of real cost series from ~/.claude/stats-cache.json:
{"date":"2026-02-24","cost":0.7148,"tokens":60704,"byModel":{"opus":{"tokens":60704,"cost":0.7148}}}
{"date":"2026-02-25","cost":0.3532,"tokens":29996,"byModel":{"opus":{"tokens":29996,"cost":0.3532}}}
{"date":"2026-02-26","cost":0.2341,"tokens":19883,"byModel":{"opus":{"tokens":19877,"cost":0.2341},"sonnet":{"tokens":6,"cost":0}}}
{"date":"2026-02-27","cost":3.921,"tokens":332991,"byModel":{"opus":{"tokens":332991,"cost":3.921}}}
{"date":"2026-02-28","cost":2.7953,"tokens":237395,"byModel":{"opus":{"tokens":237395,"cost":2.7953}}}
\`\`\`

## Files changed
- \`src/install-meta.js\` — new module: \`recordInstall()\`, \`readInstall()\`, \`installPath()\`
- \`src/init-command.js\` — calls \`installMeta.recordInstall()\` during setup (idempotent, logs date)
- \`src/calculator.js\` — adds \`buildDailyCostSeries(dailyModelTokens, days)\`
- \`src/server.js\` — exposes \`installDate\` and \`dailyCostSeries\` on \`/api/dashboard\`
- \`test/install-cost.test.js\` — 9 tests, all passing

## Pass criteria (from #82)
- [x] \`~/.token-coach/install.json\` exists after \`init\` with valid ISO timestamp
- [x] Install date never overwritten on re-run of init
- [x] \`/api/dashboard\` returns \`installDate\` + \`dailyCostSeries\`
- [x] Existing dashboard fields unchanged (additive only)
- [x] Daily cost numbers derived from real token counts
- [ ] Manual: cross-check \`dailyCostSeries\` sums against \`claude /cost\` output

## Test plan
- [x] \`node test/install-cost.test.js\` → 9/9 pass
- [x] \`node test/classifier-benchmark.js\` → 204/206 (no regression)
- [x] Smoke test against live \`stats-cache.json\` — returns reasonable per-day numbers
- [ ] Manual: restart dashboard, hit \`/api/dashboard\`, verify \`installDate\` and \`dailyCostSeries\` are present

## Caveats
- Blended rate approximation — not exact match with \`claude /cost\` for historical days (input/output split not in stats-cache). Today's numbers remain accurate via \`readSessionTokenUsage()\`.
- \`install.json\` only records the date of the FIRST init. Users who installed before this PR will get their install date recorded on their next \`update\`/\`init\` — which is fine for the "since install" chart (zero baseline starts from that day forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)