### PR TITLE
feat: add statusline with session and weekly rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ No `npm install` needed. Zero dependencies. Seriously — zero.
 
 **Then restart Claude Code** (exit completely and relaunch). Hooks do not take effect until you restart.
 
+### Optional: terminal statusline
+
+Add `--statusline` to show your session and weekly rate limits directly in the Claude Code terminal:
+
+```bash
+node bin/cli.js init --statusline
+```
+
+This installs `statusline-command.sh` to `~/.claude/` and wires it into your settings. After restarting Claude Code you'll see:
+
+```
+user@host project  |  Sonnet 4.6  |  ctx [███░░░░░░░] 38%  |  sess 46% (resets 1h13m)  |  wk 31% (resets 5d2h)
+```
+
+- **ctx** — context window fill (how full your 200K window is)
+- **sess** — 5-hour rolling session rate limit with reset countdown
+- **wk** — weekly rate limit with days until reset
+
+Rate limit percentages are the same numbers shown in the Claude app's Plan usage screen — pulled directly from Anthropic's data in the statusline JSON.
+
 ---
 
 ## Update

--- a/src/init-command.js
+++ b/src/init-command.js
@@ -483,6 +483,26 @@ function parsePort(args) {
   return null;
 }
 
+function installStatusline(repoDir, settings) {
+  const dest = path.join(CLAUDE_DIR, 'statusline-command.sh');
+  const src = path.join(repoDir, 'statusline-command.sh');
+  try {
+    fs.copyFileSync(src, dest);
+    fs.chmodSync(dest, 0o755);
+    if (!settings.statusLine) {
+      settings.statusLine = { type: 'command', command: `bash ${dest}` };
+      ok(`Statusline installed: ${dest}`);
+      info('Shows session %, weekly %, and context window in your terminal.');
+    } else {
+      ok(`Statusline script copied to ${dest}`);
+      info('Your settings.json already has a statusLine — update it manually if needed:');
+      info(`  "statusLine": { "type": "command", "command": "bash ${dest}" }`);
+    }
+  } catch (e) {
+    warn(`Could not install statusline: ${e.message}`);
+  }
+}
+
 function printInit(args = []) {
   const repoDir = path.resolve(path.join(__dirname, '..'));
   const isDiagnose = args.includes('--doctor') || args.includes('doctor');
@@ -538,10 +558,16 @@ function printInit(args = []) {
     ok(`All ${HOOK_EVENTS.length} hooks already installed`);
   }
 
-  // Step 5: PM2 dashboard
+  // Step 5: Install statusline (if --statusline flag passed or settings has no statusLine)
+  if (args.includes('--statusline')) {
+    installStatusline(repoDir, settings);
+    writeSettings(settings);
+  }
+
+  // Step 6 (was 5): PM2 dashboard
   setupPm2(repoDir);
 
-  // Step 6: npm link (makes `claude-tokens` and `token-coach` available globally)
+  // Step 7: npm link (makes `claude-tokens` and `token-coach` available globally)
   try {
     execSync('npm link 2>/dev/null', { cwd: repoDir, encoding: 'utf-8', stdio: 'pipe' });
     ok('Global commands installed (claude-tokens, token-coach)');
@@ -549,13 +575,13 @@ function printInit(args = []) {
     info('Could not run npm link -- run with sudo or use: node bin/cli.js <command>');
   }
 
-  // Step 7: Validate router
+  // Step 8: Validate router
   console.log('');
   const c = classifyTask('search for all files containing TODO');
   const r = recommendModel(c);
   ok(`Router test: "search for TODOs" -> ${r.model} (${c.family}/${c.complexity})`);
 
-  // Step 8: End-to-end hook verification — actually fire the hook and check output
+  // Step 9: End-to-end hook verification — actually fire the hook and check output
   verifyHookWorks(repoDir);
 
   const port = getPort();

--- a/statusline-command.sh
+++ b/statusline-command.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# Claude Code statusline script — Claude Token Tracker
+#
+# Shows: session rate limit %, weekly rate limit %, and context window fill.
+# Rate limits come from Anthropic's servers via the statusline JSON input.
+#
+# Install:
+#   1. Copy this file somewhere (e.g. ~/.claude/statusline-command.sh)
+#   2. Add to ~/.claude/settings.json:
+#        "statusLine": { "type": "command", "command": "bash ~/.claude/statusline-command.sh" }
+#   3. Restart Claude Code.
+#
+# Or just run: node bin/cli.js init --statusline
+# and it will install this for you automatically.
+
+input=$(cat)
+
+# --- Directory ---
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
+dir=$(basename "$cwd")
+home_base=$(basename "$HOME")
+[ "$dir" = "$home_base" ] && dir="~"
+ps1_part="$(whoami)@$(hostname -s) $dir"
+
+# --- Model ---
+model=$(echo "$input" | jq -r '.model.display_name // ""')
+
+# --- Context window bar ---
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+if [ -n "$used_pct" ]; then
+  used_int=$(printf "%.0f" "$used_pct")
+  filled=$(( used_int / 10 ))
+  empty=$(( 10 - filled ))
+  bar=""
+  i=0
+  while [ $i -lt $filled ]; do bar="${bar}█"; i=$(( i + 1 )); done
+  i=0
+  while [ $i -lt $empty ]; do bar="${bar}░"; i=$(( i + 1 )); done
+  ctx_part="ctx [${bar}] ${used_int}%"
+else
+  ctx_part="ctx [░░░░░░░░░░] --%"
+fi
+
+# --- Session rate limit (5-hour rolling window) ---
+sess_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+sess_resets=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+if [ -n "$sess_pct" ]; then
+  sess_int=$(printf "%.0f" "$sess_pct")
+  if [ -n "$sess_resets" ]; then
+    now_ts=$(date +%s)
+    diff=$(( sess_resets - now_ts ))
+    if [ $diff -gt 0 ]; then
+      hrs=$(( diff / 3600 ))
+      mins=$(( (diff % 3600) / 60 ))
+      [ $hrs -gt 0 ] && reset_label="${hrs}h${mins}m" || reset_label="${mins}m"
+      sess_part="sess ${sess_int}% (resets ${reset_label})"
+    else
+      sess_part="sess ${sess_int}%"
+    fi
+  else
+    sess_part="sess ${sess_int}%"
+  fi
+else
+  sess_part="sess --%"
+fi
+
+# --- Weekly rate limit (7-day rolling window) ---
+week_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+week_resets=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+if [ -n "$week_pct" ]; then
+  week_int=$(printf "%.0f" "$week_pct")
+  if [ -n "$week_resets" ]; then
+    now_ts=$(date +%s)
+    diff=$(( week_resets - now_ts ))
+    if [ $diff -gt 0 ]; then
+      days=$(( diff / 86400 ))
+      hrs=$(( (diff % 86400) / 3600 ))
+      mins=$(( (diff % 3600) / 60 ))
+      if [ $days -gt 0 ]; then
+        wreset_label="${days}d${hrs}h"
+      else
+        wreset_label="${hrs}h${mins}m"
+      fi
+      week_part="wk ${week_int}% (resets ${wreset_label})"
+    else
+      week_part="wk ${week_int}%"
+    fi
+  else
+    week_part="wk ${week_int}%"
+  fi
+else
+  week_part="wk --%"
+fi
+
+# --- Permission mode ---
+perm_mode=$(echo "$input" | jq -r '.permissions.mode // ""')
+case "$perm_mode" in
+  bypassPermissions) perm_part="BYPASS" ;;
+  *) perm_part="" ;;
+esac
+
+if [ -n "$perm_part" ]; then
+  printf "%s  |  %s  |  %s  |  %s  |  %s  |  %s\n" "$ps1_part" "$model" "$ctx_part" "$sess_part" "$week_part" "$perm_part"
+else
+  printf "%s  |  %s  |  %s  |  %s  |  %s\n" "$ps1_part" "$model" "$ctx_part" "$sess_part" "$week_part"
+fi


### PR DESCRIPTION
Adds statusline-command.sh that shows real-time plan usage limits directly in the Claude Code terminal — same data as the Claude app's Plan usage screen (five_hour and seven_day rate_limits from the statusline JSON).

Install with: node bin/cli.js init --statusline

Shows: directory, model, context window bar, session % with reset countdown, weekly % with reset countdown, and BYPASS mode indicator.