### PR TITLE
feat(#92): add JSONL transcript scanner alongside stats-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,10 @@ test/
 
 ---
 
+## Acknowledgments
+
+The per-session JSONL transcript scanner ([`src/jsonl-scanner.js`](src/jsonl-scanner.js)) is inspired by [phuryn/claude-usage](https://github.com/phuryn/claude-usage) (MIT). Our port is Node + zero-deps with file-based storage; the original is Python + SQLite. The key insights — dedup by `message.id` and incremental mtime-gated scans of `~/.claude/projects/**/*.jsonl` — come from that project.
+
 ## License
 
 MIT

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -57,8 +57,42 @@ if (command === 'serve' || command === 'dashboard') {
   handleModels(args.slice(1));
 } else if (command === 'regenerate-map' || command === 'regen-map') {
   handleRegenerateMap();
+} else if (command === 'scan') {
+  handleScan();
 } else {
   printSummary();
+}
+
+function handleScan() {
+  const scanner = require(path.join(__dirname, '..', 'src', 'jsonl-scanner'));
+  const t0 = Date.now();
+  const result = scanner.scan();
+  const dt = ((Date.now() - t0) / 1000).toFixed(2);
+
+  console.log(`Scanned ${result.filesScanned} file(s), skipped ${result.filesSkipped} unchanged in ${dt}s`);
+  if (result.filesRemoved > 0) console.log(`  Removed ${result.filesRemoved} stale entries`);
+  console.log(`  Roots: ${result.roots.join(', ') || '(none found)'}`);
+  console.log(`  Days aggregated: ${result.days}`);
+
+  const summary = scanner.summarize();
+  if (summary.days === 0) {
+    console.log('\nNo usage data yet. Run Claude Code and try again.');
+    return;
+  }
+  console.log(`\n${summary.days} day(s), ${summary.sessions} session(s) tracked`);
+  console.log('Totals by model:');
+  const rows = Object.entries(summary.byModel).sort((a, b) => (b[1].turns || 0) - (a[1].turns || 0));
+  for (const [model, b] of rows) {
+    const cost = calculator.calculateUsageCost(model, b);
+    console.log(
+      `  ${model.padEnd(30)} ` +
+      `in=${b.input.toLocaleString().padStart(10)} ` +
+      `out=${b.output.toLocaleString().padStart(8)} ` +
+      `cR=${b.cacheRead.toLocaleString().padStart(11)} ` +
+      `cW=${b.cacheWrite.toLocaleString().padStart(10)} ` +
+      `$${cost.total.toFixed(2)}`
+    );
+  }
 }
 
 function handleRegenerateMap() {

--- a/public/index.html
+++ b/public/index.html
@@ -451,9 +451,70 @@ async function load() {
   try {
     DATA = await (await fetch('/api/dashboard')).json();
     isFirst ? render() : softRefresh();
+    loadReconcile();
   } catch (e) {
     if (isFirst) document.getElementById('app').innerHTML = `<div class="loading">Error: ${e.message}</div>`;
   }
+}
+
+async function loadReconcile() {
+  const target = document.getElementById('v-reconcile-body');
+  if (!target) return;
+  try {
+    const r = await (await fetch('/api/reconcile')).json();
+    target.innerHTML = renderReconcile(r);
+  } catch (e) {
+    target.innerHTML = `<div style="color:var(--danger)">Reconciliation failed: ${esc(e.message)}</div>`;
+  }
+}
+
+function renderReconcile(r) {
+  if (!r || !r.summary) return '<div>No reconciliation data available.</div>';
+  const s = r.summary;
+  const divergent = (r.rows || [])
+    .filter(x => x.statsCache > 0 && x.jsonl > 0)
+    .sort((a, b) => Math.abs(b.pct || 0) - Math.abs(a.pct || 0))
+    .slice(0, 10);
+
+  const fmt = n => (n || 0).toLocaleString();
+  const ratio = (a, b) => (a > 0 && b > 0) ? (b / a).toFixed(1) + 'x' : '—';
+
+  const onlyStats = (r.rows || []).filter(x => x.statsCache > 0 && x.jsonl === 0).length;
+  const onlyJsonl = (r.rows || []).filter(x => x.statsCache === 0 && x.jsonl > 0).length;
+
+  return `
+    <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:12px">
+      <div><div style="font-size:10px;color:var(--dim);text-transform:uppercase;letter-spacing:0.5px">stats-cache total</div><div style="font-size:16px;color:var(--fg);font-family:var(--mono);margin-top:2px">${fmt(s.totalStatsCache)}</div></div>
+      <div><div style="font-size:10px;color:var(--dim);text-transform:uppercase;letter-spacing:0.5px">JSONL total</div><div style="font-size:16px;color:var(--fg);font-family:var(--mono);margin-top:2px">${fmt(s.totalJsonl)}</div></div>
+      <div><div style="font-size:10px;color:var(--dim);text-transform:uppercase;letter-spacing:0.5px">ratio</div><div style="font-size:16px;color:var(--fg);font-family:var(--mono);margin-top:2px">${ratio(s.totalStatsCache, s.totalJsonl)}</div></div>
+      <div><div style="font-size:10px;color:var(--dim);text-transform:uppercase;letter-spacing:0.5px">days compared</div><div style="font-size:16px;color:var(--fg);font-family:var(--mono);margin-top:2px">${s.days}</div></div>
+    </div>
+    ${onlyStats || onlyJsonl ? `<div style="font-size:11px;color:var(--dim);margin-bottom:8px">${onlyStats} day(s) only in stats-cache (JSONL likely rotated) · ${onlyJsonl} day(s) only in JSONL</div>` : ''}
+    <div style="font-size:11px;color:var(--dim);margin-bottom:6px">Top divergent days (both sources have data):</div>
+    <table style="width:100%;border-collapse:collapse;font-family:var(--mono);font-size:11px">
+      <thead>
+        <tr style="color:var(--dim);text-align:right">
+          <th style="text-align:left;padding:4px 8px 4px 0;font-weight:500;border-bottom:1px solid var(--separator)">date</th>
+          <th style="padding:4px 8px;font-weight:500;border-bottom:1px solid var(--separator)">stats-cache</th>
+          <th style="padding:4px 8px;font-weight:500;border-bottom:1px solid var(--separator)">JSONL</th>
+          <th style="padding:4px 8px;font-weight:500;border-bottom:1px solid var(--separator)">ratio</th>
+          <th style="padding:4px 0 4px 8px;font-weight:500;border-bottom:1px solid var(--separator)">JSONL cost</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${divergent.map(x => `
+          <tr style="color:var(--muted);text-align:right">
+            <td style="text-align:left;padding:3px 8px 3px 0;color:var(--fg)">${esc(x.date)}</td>
+            <td style="padding:3px 8px">${fmt(x.statsCache)}</td>
+            <td style="padding:3px 8px">${fmt(x.jsonl)}</td>
+            <td style="padding:3px 8px;color:var(--accent)">${ratio(x.statsCache, x.jsonl)}</td>
+            <td style="padding:3px 0 3px 8px">$${x.jsonlCost.toFixed(2)}</td>
+          </tr>
+        `).join('')}
+      </tbody>
+    </table>
+    <div style="font-size:10px;color:var(--dim);margin-top:8px">Issue <a href="https://github.com/imwebdev/claude-token-tracker/issues/92" style="color:var(--accent)" target="_blank">#92</a> — JSONL transcripts are the new source of truth. Cutover tracked in <a href="https://github.com/imwebdev/claude-token-tracker/issues/93" style="color:var(--accent)" target="_blank">#93</a>.</div>
+  `;
 }
 
 function $(v) { return typeof v === 'number' ? v.toLocaleString() : v; }
@@ -663,6 +724,13 @@ function buildHTML() {
           <p><strong style="color:var(--fg)">Be specific.</strong> File paths, line numbers, exact changes. Vague = more tokens.</p>
         </div>
       </div>
+    </div>
+
+    <div class="card anim d3" style="margin-top:12px" id="v-reconcile-card">
+      <div class="card-hd">
+        <h2>Data source reconciliation <span style="font-weight:400;font-size:11px;color:var(--dim);letter-spacing:0">#92 · stats-cache vs JSONL</span></h2>
+      </div>
+      <div id="v-reconcile-body" style="font-size:12px;color:var(--muted)">Loading…</div>
     </div>
 
     </main>

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -274,15 +274,77 @@ function buildDailyCostSeries(dailyModelTokens, days = 30) {
   });
 }
 
+/**
+ * Cost for a single usage object with the four raw token types.
+ * Used by the JSONL scanner path (src/jsonl-scanner.js). Unlike calculateModelCost
+ * which takes camelCase stats-cache-style field names, this takes the canonical
+ * four-way breakdown directly.
+ *
+ * @param {string} modelId — full model ID (e.g. "claude-sonnet-4-6")
+ * @param {{input:number, output:number, cacheRead:number, cacheWrite:number}} usage
+ */
+function calculateUsageCost(modelId, usage) {
+  const price = getModelPrice(modelId);
+  const m = 1_000_000;
+  const input      = ((usage.input      || 0) / m) * price.input;
+  const output     = ((usage.output     || 0) / m) * price.output;
+  const cacheRead  = ((usage.cacheRead  || 0) / m) * price.cacheRead;
+  const cacheWrite = ((usage.cacheWrite || 0) / m) * price.cacheWrite;
+  return { input, output, cacheRead, cacheWrite, total: input + output + cacheRead + cacheWrite };
+}
+
+/**
+ * Per-day cost series from JSONL scanner daily records.
+ *
+ * @param {Array<{date:string, sessions:number, byModel:Object}>} dailyUsage
+ *   Output of jsonl-scanner.readDailyUsage()
+ * @param {number} days — tail window (default 30)
+ * @returns {Array<{date, cost, tokens, sessions, byModel:{<tier>:{tokens, cost, input, output, cacheRead, cacheWrite}}}>}
+ */
+function buildDailyCostSeriesFromJsonl(dailyUsage, days = 30) {
+  if (!Array.isArray(dailyUsage) || dailyUsage.length === 0) return [];
+  return dailyUsage.slice(-days).map(d => {
+    let totalCost = 0;
+    let totalTokens = 0;
+    const byTier = {};
+    for (const [modelId, u] of Object.entries(d.byModel || {})) {
+      const tier = getModelTier(modelId);
+      const cost = calculateUsageCost(modelId, u);
+      const tokens = (u.input || 0) + (u.output || 0) + (u.cacheRead || 0) + (u.cacheWrite || 0);
+      totalCost += cost.total;
+      totalTokens += tokens;
+      if (!byTier[tier]) byTier[tier] = { tokens: 0, cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+      byTier[tier].tokens     += tokens;
+      byTier[tier].cost       += cost.total;
+      byTier[tier].input      += u.input      || 0;
+      byTier[tier].output     += u.output     || 0;
+      byTier[tier].cacheRead  += u.cacheRead  || 0;
+      byTier[tier].cacheWrite += u.cacheWrite || 0;
+    }
+    for (const t of Object.keys(byTier)) {
+      byTier[t].cost = Math.round(byTier[t].cost * 10000) / 10000;
+    }
+    return {
+      date: d.date,
+      cost: Math.round(totalCost * 10000) / 10000,
+      tokens: totalTokens,
+      sessions: d.sessions || 0,
+      byModel: byTier,
+    };
+  });
+}
+
 module.exports = {
   PRICING,
   getModelPrice,
   getModelTier,
   calculateModelCost,
+  calculateUsageCost,
   calculateTotalCosts,
   calculateOptimalCost,
   estimateSessionCost,
   calculateCounterfactual,
   calculateDailySavings,
   buildDailyCostSeries,
+  buildDailyCostSeriesFromJsonl,
 };

--- a/src/jsonl-scanner.js
+++ b/src/jsonl-scanner.js
@@ -1,0 +1,288 @@
+/**
+ * JSONL transcript scanner.
+ *
+ * Reads Claude Code's per-session JSONL transcripts from ~/.claude/projects/ (and
+ * the Xcode integration dir on macOS) and aggregates token usage into per-day
+ * buckets under ~/.token-coach/usage/YYYY-MM-DD.json.
+ *
+ * Why this exists: stats-cache.json is pre-aggregated, goes stale, and cannot
+ * separate cache-creation from cache-read tokens. JSONL transcripts are the
+ * ground-truth Claude Code writes on every turn.
+ *
+ * Dedup: Claude Code logs multiple JSONL records per API response (one per
+ * content block) with the same message.id. Last record per id wins — matches
+ * phuryn/claude-usage behavior.
+ *
+ * Incremental: per-file mtime+size gate via ~/.token-coach/scan-manifest.json.
+ * Unchanged files keep their cached per-file aggregates; changed files get
+ * re-parsed.
+ *
+ * Inspired by phuryn/claude-usage (MIT). Ported to Node/CommonJS + file-based
+ * storage to match this project's zero-deps design.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const dataHome = require('./data-home');
+
+const CLAUDE_PROJECTS = path.join(os.homedir(), '.claude', 'projects');
+const XCODE_PROJECTS = path.join(
+  os.homedir(),
+  'Library', 'Developer', 'Xcode',
+  'CodingAssistant', 'ClaudeAgentConfig', 'projects'
+);
+
+const MANIFEST_NAME = 'scan-manifest.json';
+const USAGE_DIRNAME = 'usage';
+
+function getManifestPath() {
+  return dataHome.getPath(MANIFEST_NAME);
+}
+
+function getUsageDir() {
+  return dataHome.getPath(USAGE_DIRNAME);
+}
+
+function readManifest() {
+  const fp = getManifestPath();
+  if (!fs.existsSync(fp)) return { files: {}, lastScan: null };
+  try {
+    const m = JSON.parse(fs.readFileSync(fp, 'utf-8'));
+    if (!m || typeof m !== 'object') return { files: {}, lastScan: null };
+    if (!m.files || typeof m.files !== 'object') m.files = {};
+    return m;
+  } catch {
+    return { files: {}, lastScan: null };
+  }
+}
+
+function writeManifest(manifest) {
+  dataHome.ensureDataHome();
+  fs.writeFileSync(getManifestPath(), JSON.stringify(manifest, null, 2));
+}
+
+function* walkJsonl(root) {
+  if (!fs.existsSync(root)) return;
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+    catch { continue; }
+    for (const e of entries) {
+      const fp = path.join(dir, e.name);
+      if (e.isDirectory()) stack.push(fp);
+      else if (e.isFile() && fp.endsWith('.jsonl')) yield fp;
+    }
+  }
+}
+
+function isTrackedModel(model) {
+  if (!model) return false;
+  const s = String(model).toLowerCase();
+  return s.includes('opus') || s.includes('sonnet') || s.includes('haiku');
+}
+
+/**
+ * Parse one JSONL file into per-day×model aggregates.
+ *
+ * Returns {
+ *   daily: {
+ *     "YYYY-MM-DD": {
+ *       byModel: { "<modelId>": { input, output, cacheRead, cacheWrite, turns } },
+ *       sessions: [sessionId, ...]
+ *     }
+ *   }
+ * }
+ */
+function parseFile(filepath) {
+  let raw;
+  try { raw = fs.readFileSync(filepath, 'utf-8'); }
+  catch { return { daily: {} }; }
+
+  const seenById = new Map();
+  const unkeyed = [];
+
+  for (const line of raw.split('\n')) {
+    if (!line) continue;
+    let rec;
+    try { rec = JSON.parse(line); }
+    catch { continue; }
+    if (!rec || rec.type !== 'assistant') continue;
+
+    const msg = rec.message || {};
+    const usage = msg.usage || {};
+    const model = msg.model;
+    if (!isTrackedModel(model)) continue;
+
+    const turn = {
+      sessionId: rec.sessionId || '',
+      timestamp: rec.timestamp || '',
+      model,
+      input:      usage.input_tokens || 0,
+      output:     usage.output_tokens || 0,
+      cacheRead:  usage.cache_read_input_tokens || 0,
+      cacheWrite: usage.cache_creation_input_tokens || 0,
+    };
+    const id = msg.id;
+    if (id) seenById.set(id, turn);
+    else unkeyed.push(turn);
+  }
+
+  const turns = [...seenById.values(), ...unkeyed];
+  const daily = {};
+  const sessionsByDate = {};
+
+  for (const t of turns) {
+    const date = (t.timestamp || '').slice(0, 10);
+    if (!date) continue;
+    if (!daily[date]) daily[date] = { byModel: {} };
+    if (!sessionsByDate[date]) sessionsByDate[date] = new Set();
+    if (t.sessionId) sessionsByDate[date].add(t.sessionId);
+    const bm = daily[date].byModel;
+    if (!bm[t.model]) bm[t.model] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, turns: 0 };
+    bm[t.model].input      += t.input;
+    bm[t.model].output     += t.output;
+    bm[t.model].cacheRead  += t.cacheRead;
+    bm[t.model].cacheWrite += t.cacheWrite;
+    bm[t.model].turns      += 1;
+  }
+
+  for (const date of Object.keys(daily)) {
+    daily[date].sessions = [...sessionsByDate[date]];
+  }
+
+  return { daily };
+}
+
+function mergeModelBucket(dest, src) {
+  dest.input      = (dest.input      || 0) + (src.input      || 0);
+  dest.output     = (dest.output     || 0) + (src.output     || 0);
+  dest.cacheRead  = (dest.cacheRead  || 0) + (src.cacheRead  || 0);
+  dest.cacheWrite = (dest.cacheWrite || 0) + (src.cacheWrite || 0);
+  dest.turns      = (dest.turns      || 0) + (src.turns      || 0);
+}
+
+function scan(opts = {}) {
+  dataHome.ensureDataHome();
+  const usageDir = getUsageDir();
+  if (!fs.existsSync(usageDir)) fs.mkdirSync(usageDir, { recursive: true });
+
+  const roots = (opts.roots && opts.roots.length)
+    ? opts.roots
+    : [CLAUDE_PROJECTS, XCODE_PROJECTS].filter(r => fs.existsSync(r));
+
+  const manifest = readManifest();
+  const nextFiles = {};
+  let filesScanned = 0;
+  let filesSkipped = 0;
+  let filesRemoved = 0;
+
+  const seenFilepaths = new Set();
+
+  for (const root of roots) {
+    for (const fp of walkJsonl(root)) {
+      seenFilepaths.add(fp);
+      let stat;
+      try { stat = fs.statSync(fp); }
+      catch { continue; }
+      const prev = manifest.files[fp];
+      if (prev && prev.mtime === stat.mtimeMs && prev.size === stat.size && prev.daily) {
+        nextFiles[fp] = prev;
+        filesSkipped++;
+        continue;
+      }
+      const { daily } = parseFile(fp);
+      nextFiles[fp] = { mtime: stat.mtimeMs, size: stat.size, daily };
+      filesScanned++;
+    }
+  }
+
+  for (const fp of Object.keys(manifest.files)) {
+    if (!seenFilepaths.has(fp)) filesRemoved++;
+  }
+
+  const dailyAgg = {};
+  const sessionsByDate = {};
+  for (const entry of Object.values(nextFiles)) {
+    for (const [date, perDay] of Object.entries(entry.daily || {})) {
+      if (!dailyAgg[date]) dailyAgg[date] = { date, byModel: {} };
+      if (!sessionsByDate[date]) sessionsByDate[date] = new Set();
+      for (const s of perDay.sessions || []) sessionsByDate[date].add(s);
+      for (const [model, bucket] of Object.entries(perDay.byModel || {})) {
+        if (!dailyAgg[date].byModel[model]) {
+          dailyAgg[date].byModel[model] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, turns: 0 };
+        }
+        mergeModelBucket(dailyAgg[date].byModel[model], bucket);
+      }
+    }
+  }
+
+  for (const [date, d] of Object.entries(dailyAgg)) {
+    const out = {
+      date,
+      sessions: sessionsByDate[date].size,
+      byModel: d.byModel,
+    };
+    fs.writeFileSync(path.join(usageDir, `${date}.json`), JSON.stringify(out, null, 2));
+  }
+
+  if (filesRemoved > 0) {
+    for (const f of fs.readdirSync(usageDir)) {
+      if (!f.endsWith('.json')) continue;
+      const date = f.replace(/\.json$/, '');
+      if (!dailyAgg[date]) {
+        try { fs.unlinkSync(path.join(usageDir, f)); } catch {}
+      }
+    }
+  }
+
+  writeManifest({ files: nextFiles, lastScan: new Date().toISOString() });
+
+  return {
+    filesScanned,
+    filesSkipped,
+    filesRemoved,
+    days: Object.keys(dailyAgg).length,
+    roots,
+  };
+}
+
+function readDailyUsage() {
+  const dir = getUsageDir();
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.endsWith('.json')) continue;
+    try { out.push(JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8'))); }
+    catch {}
+  }
+  return out.sort((a, b) => String(a.date).localeCompare(String(b.date)));
+}
+
+function summarize(daily = null) {
+  const rows = daily || readDailyUsage();
+  const totalsByModel = {};
+  let sessions = 0;
+  for (const d of rows) {
+    sessions += d.sessions || 0;
+    for (const [model, b] of Object.entries(d.byModel || {})) {
+      if (!totalsByModel[model]) totalsByModel[model] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, turns: 0 };
+      mergeModelBucket(totalsByModel[model], b);
+    }
+  }
+  return { days: rows.length, sessions, byModel: totalsByModel };
+}
+
+module.exports = {
+  scan,
+  readDailyUsage,
+  summarize,
+  getManifestPath,
+  getUsageDir,
+  parseFile,
+  isTrackedModel,
+  CLAUDE_PROJECTS,
+  XCODE_PROJECTS,
+};

--- a/src/server.js
+++ b/src/server.js
@@ -6,8 +6,9 @@ const calculator = require('./calculator');
 const { generateInsights } = require('./insights');
 const events = require('./events');
 const { getLearningStats } = require('./learner');
-const { calculateCounterfactual, calculateDailySavings, buildDailyCostSeries } = require('./calculator');
+const { calculateCounterfactual, calculateDailySavings, buildDailyCostSeries, buildDailyCostSeriesFromJsonl, getModelTier, calculateUsageCost } = require('./calculator');
 const installMeta = require('./install-meta');
+const jsonlScanner = require('./jsonl-scanner');
 
 const config = require('./config');
 const os = require('os');
@@ -456,6 +457,9 @@ function buildDashboardData() {
     // Per-day cost series built from real stats-cache token counts (last 30 days).
     // [{ date, cost, tokens, byModel: { opus: { tokens, cost }, sonnet: ..., haiku: ... } }]
     dailyCostSeries: buildDailyCostSeries(stats?.dailyModelTokens, 30),
+    // Per-day cost series from JSONL transcripts (new source, parallel run for #92).
+    // Includes input/output/cacheRead/cacheWrite breakdown per tier.
+    dailyCostSeriesJsonl: buildDailyCostSeriesFromJsonl(jsonlScanner.readDailyUsage(), 30),
     // Install metadata — anchor point for "cost since install" visualizations
     installDate: installMeta.readInstall()?.installed_at || null,
     // Read-deduper: tokens saved by hard-blocking redundant reads
@@ -463,6 +467,75 @@ function buildDashboardData() {
     dedupeStats: events.getDedupeStats({ days: 30 }),
     // Efficiency analysis / grading
     analysis,
+  };
+}
+
+/**
+ * Reconciliation: per-day totals from stats-cache (old source) vs JSONL
+ * transcripts (new source). Surfaces divergence so we can verify the new
+ * source before retiring stats-cache in #93.
+ */
+function buildReconciliation() {
+  try { jsonlScanner.scan(); } catch { /* best-effort */ }
+
+  const stats = parser.readStatsCache();
+  const staleMap = {};
+  for (const d of (stats?.dailyModelTokens || [])) {
+    const row = { date: d.date, totalTokens: 0, byTier: {} };
+    for (const [modelId, tokens] of Object.entries(d.tokensByModel || {})) {
+      const tier = getModelTier(modelId);
+      row.totalTokens += tokens;
+      row.byTier[tier] = (row.byTier[tier] || 0) + tokens;
+    }
+    staleMap[d.date] = row;
+  }
+
+  const jsonlMap = {};
+  for (const d of jsonlScanner.readDailyUsage()) {
+    const row = { date: d.date, totalTokens: 0, totalCost: 0, byTier: {} };
+    for (const [modelId, u] of Object.entries(d.byModel || {})) {
+      const tier = getModelTier(modelId);
+      const tokens = (u.input || 0) + (u.output || 0) + (u.cacheRead || 0) + (u.cacheWrite || 0);
+      const cost = calculateUsageCost(modelId, u).total;
+      row.totalTokens += tokens;
+      row.totalCost += cost;
+      row.byTier[tier] = (row.byTier[tier] || 0) + tokens;
+    }
+    jsonlMap[d.date] = row;
+  }
+
+  const dates = new Set([...Object.keys(staleMap), ...Object.keys(jsonlMap)]);
+  const rows = [...dates].sort().map(date => {
+    const sc = staleMap[date] || { totalTokens: 0, byTier: {} };
+    const jl = jsonlMap[date] || { totalTokens: 0, totalCost: 0, byTier: {} };
+    const diff = jl.totalTokens - sc.totalTokens;
+    const pct = sc.totalTokens > 0 ? (diff / sc.totalTokens) * 100 : null;
+    return {
+      date,
+      statsCache: sc.totalTokens,
+      jsonl: jl.totalTokens,
+      jsonlCost: Math.round(jl.totalCost * 100) / 100,
+      diff,
+      pct: pct !== null ? Math.round(pct * 10) / 10 : null,
+      byTier: { statsCache: sc.byTier, jsonl: jl.byTier },
+    };
+  });
+
+  const totalStats = rows.reduce((a, r) => a + r.statsCache, 0);
+  const totalJsonl = rows.reduce((a, r) => a + r.jsonl, 0);
+
+  return {
+    lastScan: (jsonlScanner.readDailyUsage().length > 0)
+      ? (JSON.parse(fs.readFileSync(jsonlScanner.getManifestPath(), 'utf-8')).lastScan || null)
+      : null,
+    summary: {
+      days: rows.length,
+      totalStatsCache: totalStats,
+      totalJsonl,
+      diff: totalJsonl - totalStats,
+      pct: totalStats > 0 ? Math.round(((totalJsonl - totalStats) / totalStats) * 1000) / 10 : null,
+    },
+    rows,
   };
 }
 
@@ -535,6 +608,18 @@ const server = http.createServer((req, res) => {
       else enableHooks();
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ enabled: !enabled }));
+    } catch (err) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: err.message }));
+    }
+    return;
+  }
+
+  if (req.url === '/api/reconcile') {
+    try {
+      const payload = buildReconciliation();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(payload));
     } catch (err) {
       res.writeHead(500, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: err.message }));

--- a/test/jsonl-scanner.test.js
+++ b/test/jsonl-scanner.test.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/jsonl-scanner.js.
+ * Run: node test/jsonl-scanner.test.js
+ */
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-jsonl-'));
+process.env.TOKEN_COACH_HOME = TMP;
+
+const scanner = require('../src/jsonl-scanner');
+
+const results = [];
+function test(name, fn) {
+  try {
+    fn();
+    results.push({ name, ok: true });
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    results.push({ name, ok: false, err });
+    console.log(`  FAIL ${name}`);
+    console.log(`       ${err.stack || err.message}`);
+  }
+}
+
+function makeJsonlDir(layout) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-proj-'));
+  for (const [rel, lines] of Object.entries(layout)) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, lines.map(l => typeof l === 'string' ? l : JSON.stringify(l)).join('\n'));
+  }
+  return root;
+}
+
+function assistantTurn({ sessionId = 'sess1', messageId, model = 'claude-sonnet-4-6', timestamp = '2026-04-01T12:00:00Z', input = 100, output = 50, cacheRead = 1000, cacheWrite = 200 }) {
+  return {
+    type: 'assistant',
+    sessionId,
+    timestamp,
+    message: {
+      id: messageId,
+      model,
+      usage: {
+        input_tokens: input,
+        output_tokens: output,
+        cache_read_input_tokens: cacheRead,
+        cache_creation_input_tokens: cacheWrite,
+      },
+    },
+  };
+}
+
+console.log('jsonl-scanner tests');
+
+test('empty dir produces no usage', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-empty-'));
+  const r = scanner.scan({ roots: [root] });
+  assert.strictEqual(r.filesScanned, 0);
+  assert.strictEqual(r.days, 0);
+  assert.deepStrictEqual(scanner.readDailyUsage(), []);
+});
+
+test('parses assistant turn with four-token breakdown', () => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.mkdirSync(TMP, { recursive: true });
+  const root = makeJsonlDir({
+    'proj/a.jsonl': [assistantTurn({ messageId: 'm1' })],
+  });
+  const r = scanner.scan({ roots: [root] });
+  assert.strictEqual(r.filesScanned, 1);
+  const daily = scanner.readDailyUsage();
+  assert.strictEqual(daily.length, 1);
+  const bucket = daily[0].byModel['claude-sonnet-4-6'];
+  assert.strictEqual(bucket.input, 100);
+  assert.strictEqual(bucket.output, 50);
+  assert.strictEqual(bucket.cacheRead, 1000);
+  assert.strictEqual(bucket.cacheWrite, 200);
+  assert.strictEqual(bucket.turns, 1);
+});
+
+test('dedupes multiple records sharing message.id (last-write-wins)', () => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.mkdirSync(TMP, { recursive: true });
+  const root = makeJsonlDir({
+    'proj/a.jsonl': [
+      assistantTurn({ messageId: 'same', input: 100, output: 50 }),
+      assistantTurn({ messageId: 'same', input: 100, output: 50 }),
+      assistantTurn({ messageId: 'same', input: 100, output: 50 }),
+    ],
+  });
+  scanner.scan({ roots: [root] });
+  const daily = scanner.readDailyUsage();
+  const bucket = daily[0].byModel['claude-sonnet-4-6'];
+  assert.strictEqual(bucket.turns, 1, 'three records with same message.id should collapse to one turn');
+  assert.strictEqual(bucket.input, 100);
+});
+
+test('filters out non-tracked models (local, unknown)', () => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.mkdirSync(TMP, { recursive: true });
+  const root = makeJsonlDir({
+    'proj/a.jsonl': [
+      assistantTurn({ messageId: 'm1', model: 'claude-opus-4-6' }),
+      assistantTurn({ messageId: 'm2', model: 'local-llama' }),
+      assistantTurn({ messageId: 'm3', model: 'gpt-4' }),
+      assistantTurn({ messageId: 'm4', model: 'claude-haiku-4-5-20251001' }),
+    ],
+  });
+  scanner.scan({ roots: [root] });
+  const daily = scanner.readDailyUsage();
+  const models = Object.keys(daily[0].byModel).sort();
+  assert.deepStrictEqual(models, ['claude-haiku-4-5-20251001', 'claude-opus-4-6']);
+});
+
+test('isTrackedModel recognizes tier substrings', () => {
+  assert.strictEqual(scanner.isTrackedModel('claude-opus-4-7'), true);
+  assert.strictEqual(scanner.isTrackedModel('claude-sonnet-4-6'), true);
+  assert.strictEqual(scanner.isTrackedModel('claude-haiku-4-5'), true);
+  assert.strictEqual(scanner.isTrackedModel('gpt-4'), false);
+  assert.strictEqual(scanner.isTrackedModel('local-llama'), false);
+  assert.strictEqual(scanner.isTrackedModel(null), false);
+  assert.strictEqual(scanner.isTrackedModel(''), false);
+});
+
+test('ignores malformed JSONL lines without crashing', () => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.mkdirSync(TMP, { recursive: true });
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-malformed-'));
+  fs.mkdirSync(path.join(dir, 'proj'));
+  const fp = path.join(dir, 'proj', 'mixed.jsonl');
+  fs.writeFileSync(fp, [
+    'not-json',
+    '{"type":"assistant","incomplete":',
+    JSON.stringify(assistantTurn({ messageId: 'm1' })),
+    '',
+    '{}',
+  ].join('\n'));
+  scanner.scan({ roots: [dir] });
+  const daily = scanner.readDailyUsage();
+  assert.strictEqual(daily.length, 1);
+  assert.strictEqual(daily[0].byModel['claude-sonnet-4-6'].turns, 1);
+});
+
+test('incremental re-scan skips unchanged files', () => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.mkdirSync(TMP, { recursive: true });
+  const root = makeJsonlDir({
+    'proj/a.jsonl': [assistantTurn({ messageId: 'm1' })],
+    'proj/b.jsonl': [assistantTurn({ messageId: 'm2', sessionId: 'sess2' })],
+  });
+  const r1 = scanner.scan({ roots: [root] });
+  assert.strictEqual(r1.filesScanned, 2);
+  assert.strictEqual(r1.filesSkipped, 0);
+
+  const r2 = scanner.scan({ roots: [root] });
+  assert.strictEqual(r2.filesScanned, 0);
+  assert.strictEqual(r2.filesSkipped, 2);
+});
+
+test('re-scans file when mtime changes', () => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.mkdirSync(TMP, { recursive: true });
+  const root = makeJsonlDir({
+    'proj/a.jsonl': [assistantTurn({ messageId: 'm1' })],
+  });
+  scanner.scan({ roots: [root] });
+
+  const fp = path.join(root, 'proj', 'a.jsonl');
+  const content = fs.readFileSync(fp, 'utf-8');
+  fs.writeFileSync(fp, content + '\n' + JSON.stringify(assistantTurn({ messageId: 'm2' })));
+
+  const r = scanner.scan({ roots: [root] });
+  assert.strictEqual(r.filesScanned, 1);
+  assert.strictEqual(r.filesSkipped, 0);
+
+  const daily = scanner.readDailyUsage();
+  assert.strictEqual(daily[0].byModel['claude-sonnet-4-6'].turns, 2);
+});
+
+test('aggregates turns spanning multiple days into separate buckets', () => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.mkdirSync(TMP, { recursive: true });
+  const root = makeJsonlDir({
+    'proj/a.jsonl': [
+      assistantTurn({ messageId: 'm1', timestamp: '2026-04-01T23:00:00Z' }),
+      assistantTurn({ messageId: 'm2', timestamp: '2026-04-02T01:00:00Z' }),
+    ],
+  });
+  scanner.scan({ roots: [root] });
+  const daily = scanner.readDailyUsage();
+  const dates = daily.map(d => d.date).sort();
+  assert.deepStrictEqual(dates, ['2026-04-01', '2026-04-02']);
+});
+
+test('summarize produces totals across all days', () => {
+  fs.rmSync(TMP, { recursive: true, force: true });
+  fs.mkdirSync(TMP, { recursive: true });
+  const root = makeJsonlDir({
+    'proj/a.jsonl': [
+      assistantTurn({ messageId: 'm1', input: 100, output: 50, timestamp: '2026-04-01T12:00:00Z' }),
+      assistantTurn({ messageId: 'm2', input: 200, output: 80, timestamp: '2026-04-02T12:00:00Z' }),
+    ],
+  });
+  scanner.scan({ roots: [root] });
+  const s = scanner.summarize();
+  assert.strictEqual(s.days, 2);
+  const b = s.byModel['claude-sonnet-4-6'];
+  assert.strictEqual(b.input, 300);
+  assert.strictEqual(b.output, 130);
+  assert.strictEqual(b.turns, 2);
+});
+
+const passed = results.filter(r => r.ok).length;
+const failed = results.length - passed;
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed) process.exit(1);


### PR DESCRIPTION
## Summary

Closes #92 (phase 1 of 2). Adds a per-session JSONL transcript scanner alongside the existing `stats-cache.json` reader. No cutover yet — #93 handles that once reconciliation totals are trusted.

Inspired by [phuryn/claude-usage](https://github.com/phuryn/claude-usage) (MIT), ported to Node + zero-deps with file-based storage.

## What's in

- **`src/jsonl-scanner.js`** — walks `~/.claude/projects/**/*.jsonl` (+ Xcode dir on macOS), dedupes by `message.id` (last-write-wins), incremental mtime+size manifest, writes daily aggregates with four-way token breakdown (input / output / cache-read / cache-write).
- **`src/calculator.js`** — new `calculateUsageCost()` and `buildDailyCostSeriesFromJsonl()` for the JSONL source.
- **`bin/cli.js scan`** — manual trigger with per-model totals.
- **`src/server.js`** — `/api/reconcile` endpoint + `dailyCostSeriesJsonl` in the dashboard payload.
- **`public/index.html`** — "Data source reconciliation" panel showing top divergent days side-by-side with links back to #92 / #93.
- **`test/jsonl-scanner.test.js`** — 10 tests (dedup, model filter, incremental scan, multi-day aggregation, malformed JSONL).
- **`README.md`** — Acknowledgments section links phuryn/claude-usage.

## Finding from real-world reconciliation

Against 3185 real JSONL files on the author's machine:

| Source | Tokens (90 days) |
|---|---|
| stats-cache | 8.8M |
| JSONL | 2.87B |

Per-day ratio varies 60x–7000x — stats-cache isn't consistently measuring input, output, or anything else. JSONL is authoritative; stats-cache has been silently wrong.

## Test plan

- [x] `node test/jsonl-scanner.test.js` — 10/10 pass
- [x] All existing tests still pass (44/44)
- [x] `node bin/cli.js scan` parses real transcripts (6.9s cold, 0.06s warm)
- [x] `curl /api/reconcile` returns side-by-side totals
- [x] `curl /api/dashboard` includes `dailyCostSeriesJsonl` with four-way token breakdown
- [ ] **Manual verification needed:** open dashboard at :6099, confirm reconciliation panel renders and divergent rows look sensible
- [ ] **Manual verification needed:** `node bin/cli.js scan` on a fresh install produces expected totals

## Out of scope (deferred to #93)

- Removing `readStatsCache()` call sites
- Updating `insights.js` stale-stats-cache warning path
- README/CLAUDE.md doc updates that retire stats-cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)