### PR TITLE
feat(#95): dashboard-controlled routing matrix (family × complexity)

### DIFF
--- a/bin/hook-router.js
+++ b/bin/hook-router.js
@@ -154,6 +154,21 @@ function handleUserPromptSubmit(input) {
   const classification = router.classifyTask(prompt);
   const recommendation = router.recommendModel(classification);
 
+  // ── Matrix override (#95) ──────────────────────────────────────────
+  // Dashboard-configured routing matrix trumps the classifier output. If the
+  // user has set a specific (family, complexity) cell, apply it and tag the
+  // reason so the UI shows why the recommendation differs from the classifier.
+  try {
+    const configMod = require(path.join(ROOT, 'src', 'config'));
+    const matrixModel = configMod.getMatrixCell(classification.family, classification.complexity);
+    if (matrixModel && matrixModel !== recommendation.model) {
+      recommendation.classifierModel = recommendation.model;
+      recommendation.model = matrixModel;
+      recommendation.reasons = recommendation.reasons || [];
+      recommendation.reasons.unshift(`[matrix] dashboard rule: ${classification.family}/${classification.complexity} → ${matrixModel}`);
+    }
+  } catch (_) { /* matrix is best-effort; classifier output still works */ }
+
   events.logEvent('routing_decision', {
     session_id: input.session_id,
     project: getProject(input),

--- a/public/index.html
+++ b/public/index.html
@@ -451,10 +451,147 @@ async function load() {
   try {
     DATA = await (await fetch('/api/dashboard')).json();
     isFirst ? render() : softRefresh();
+    loadMatrix();
   } catch (e) {
     if (isFirst) document.getElementById('app').innerHTML = `<div class="loading">Error: ${e.message}</div>`;
   }
 }
+
+let MATRIX_STATE = null;
+
+async function loadMatrix() {
+  const target = document.getElementById('v-matrix-body');
+  if (!target) return;
+  try {
+    MATRIX_STATE = await (await fetch('/api/matrix')).json();
+    target.innerHTML = renderMatrix(MATRIX_STATE);
+  } catch (e) {
+    target.innerHTML = `<div style="color:var(--danger)">Matrix load failed: ${esc(e.message)}</div>`;
+  }
+}
+
+function renderMatrix(state) {
+  if (!state || !state.matrix) return '<div>No matrix data.</div>';
+  const { families, complexities, matrix } = state;
+  const learnerByFamilyModel = {};
+  for (const entry of state.learnerStats || []) {
+    learnerByFamilyModel[`${entry.family}:${entry.model}`] = entry;
+  }
+  function cellOptions(family, cx, current) {
+    const opts = ['haiku', 'sonnet', 'opus'].map(m => {
+      const e = learnerByFamilyModel[`${family}:${m}`];
+      const title = e ? `${m}: ${Math.round(e.rate * 100)}% success · ${e.samples} outcomes` : `${m}: no data yet`;
+      return `<option value="${m}" ${m === current ? 'selected' : ''} title="${title}">${m}</option>`;
+    }).join('');
+    return `<select data-family="${family}" data-cx="${cx}" class="matrix-cell" style="font-family:var(--mono);font-size:11px;padding:3px 5px;border:1px solid var(--border);background:var(--card);color:var(--fg);border-radius:4px">${opts}</select>`;
+  }
+  const rows = families.map(f => {
+    const row = matrix[f] || {};
+    return `
+      <tr>
+        <td style="padding:4px 8px 4px 0;color:var(--fg);font-family:var(--mono);font-size:11px">${f}</td>
+        ${complexities.map(cx => `<td style="padding:4px 8px">${cellOptions(f, cx, row[cx] || 'sonnet')}</td>`).join('')}
+      </tr>
+    `;
+  }).join('');
+  const migrationNote = state.migratedFromForceModel
+    ? `<div style="font-size:11px;color:var(--accent);margin-bottom:8px;padding:8px;background:var(--accent-dim);border-radius:4px">Migrated from <code>force_model=${esc(state.migratedFromForceModel)}</code>. All cells seeded. Adjust below and save to replace the legacy setting.</div>`
+    : '';
+  const defaultsNote = state.isUsingDefaults
+    ? `<div style="font-size:11px;color:var(--dim);margin-bottom:8px">Showing built-in defaults. Save to persist your own matrix.</div>`
+    : '';
+  return `
+    ${migrationNote}
+    ${defaultsNote}
+    <div style="overflow-x:auto">
+    <table style="border-collapse:collapse;margin-bottom:12px">
+      <thead>
+        <tr style="color:var(--dim);font-size:10px;text-transform:uppercase;letter-spacing:0.5px">
+          <th style="text-align:left;padding:4px 8px 4px 0;font-weight:500;border-bottom:1px solid var(--separator)">family</th>
+          ${complexities.map(cx => `<th style="text-align:left;padding:4px 8px;font-weight:500;border-bottom:1px solid var(--separator)">${cx}</th>`).join('')}
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+    </div>
+    <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center">
+      <button id="matrix-save" class="btn" style="padding:6px 14px;background:var(--fg);color:var(--bg);border:none;border-radius:4px;font-size:12px;cursor:pointer">Save matrix</button>
+      <button id="matrix-reset" class="btn" style="padding:6px 14px;background:transparent;color:var(--fg);border:1px solid var(--border);border-radius:4px;font-size:12px;cursor:pointer">Reset to suggested (from learner data)</button>
+      <span style="font-size:11px;color:var(--dim);margin-left:4px">Set all to:</span>
+      <select id="matrix-set-all" style="font-family:var(--mono);font-size:11px;padding:4px 6px;border:1px solid var(--border);background:var(--card);color:var(--fg);border-radius:4px">
+        <option value="">—</option>
+        <option value="haiku">haiku (equivalent to force_model=haiku)</option>
+        <option value="sonnet">sonnet</option>
+        <option value="opus">opus</option>
+      </select>
+      <span id="matrix-status" style="font-size:11px;color:var(--dim);margin-left:auto"></span>
+    </div>
+    <div style="font-size:10px;color:var(--dim);margin-top:10px">
+      Hover any cell to see learner success rate.
+      Matrix overrides the classifier — it's the primary routing source.
+      <code>force_model</code> is deprecated; setting every cell to the same model achieves the same result.
+    </div>
+  `;
+}
+
+function matrixStatus(msg, color) {
+  const el = document.getElementById('matrix-status');
+  if (!el) return;
+  el.style.color = color || 'var(--dim)';
+  el.textContent = msg;
+  if (msg) setTimeout(() => { el.textContent = ''; }, 3000);
+}
+
+function collectMatrix() {
+  const out = {};
+  document.querySelectorAll('.matrix-cell').forEach(sel => {
+    const f = sel.dataset.family;
+    const cx = sel.dataset.cx;
+    if (!out[f]) out[f] = {};
+    out[f][cx] = sel.value;
+  });
+  return out;
+}
+
+document.addEventListener('click', async (e) => {
+  if (e.target?.id === 'matrix-save') {
+    try {
+      const matrix = collectMatrix();
+      const r = await fetch('/api/matrix', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ matrix }),
+      });
+      if (!r.ok) throw new Error((await r.json()).error || 'save failed');
+      matrixStatus('Saved. Takes effect on next prompt.', 'var(--accent)');
+    } catch (err) {
+      matrixStatus(`Save failed: ${err.message}`, 'var(--danger)');
+    }
+  }
+  if (e.target?.id === 'matrix-reset') {
+    try {
+      const r = await fetch('/api/matrix/suggest');
+      const { matrix } = await r.json();
+      for (const sel of document.querySelectorAll('.matrix-cell')) {
+        const f = sel.dataset.family;
+        const cx = sel.dataset.cx;
+        if (matrix[f]?.[cx]) sel.value = matrix[f][cx];
+      }
+      matrixStatus('Reset from learner data. Click "Save matrix" to persist.', 'var(--accent)');
+    } catch (err) {
+      matrixStatus(`Reset failed: ${err.message}`, 'var(--danger)');
+    }
+  }
+});
+
+document.addEventListener('change', (e) => {
+  if (e.target?.id === 'matrix-set-all' && e.target.value) {
+    const m = e.target.value;
+    for (const sel of document.querySelectorAll('.matrix-cell')) sel.value = m;
+    e.target.value = '';
+    matrixStatus(`All cells set to ${m}. Click "Save matrix" to persist.`, 'var(--accent)');
+  }
+});
 
 function $(v) { return typeof v === 'number' ? v.toLocaleString() : v; }
 function esc(s) { if (!s) return ''; const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
@@ -663,6 +800,13 @@ function buildHTML() {
           <p><strong style="color:var(--fg)">Be specific.</strong> File paths, line numbers, exact changes. Vague = more tokens.</p>
         </div>
       </div>
+    </div>
+
+    <div class="card anim d3" style="margin-top:12px" id="v-matrix-card">
+      <div class="card-hd">
+        <h2>Routing matrix <span style="font-weight:400;font-size:11px;color:var(--dim);letter-spacing:0">#95 · per (family × complexity)</span></h2>
+      </div>
+      <div id="v-matrix-body" style="font-size:12px;color:var(--muted)">Loading…</div>
     </div>
 
     </main>

--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,29 @@
 const fs = require('fs');
 const dataHome = require('./data-home');
 
+// Families the classifier emits. Must match TASK_FAMILIES values in src/router.js.
+const FAMILIES = [
+  'search_read', 'code_edit', 'multi_file', 'debug', 'review',
+  'plan', 'architecture', 'command', 'question', 'unknown',
+];
+const COMPLEXITIES = ['low', 'medium', 'high'];
+
+// Hardcoded safe defaults for the routing matrix (#95). Used when the user has no
+// per-cell preference and learner data is insufficient to suggest one. Roughly
+// mirrors what the classifier+escalation path would pick today.
+const DEFAULT_MATRIX = {
+  search_read:  { low: 'haiku',  medium: 'haiku',  high: 'sonnet' },
+  code_edit:    { low: 'sonnet', medium: 'sonnet', high: 'opus'   },
+  multi_file:   { low: 'sonnet', medium: 'opus',   high: 'opus'   },
+  debug:        { low: 'sonnet', medium: 'opus',   high: 'opus'   },
+  review:       { low: 'haiku',  medium: 'sonnet', high: 'sonnet' },
+  plan:         { low: 'sonnet', medium: 'sonnet', high: 'opus'   },
+  architecture: { low: 'opus',   medium: 'opus',   high: 'opus'   },
+  command:      { low: 'haiku',  medium: 'sonnet', high: 'sonnet' },
+  question:     { low: 'sonnet', medium: 'sonnet', high: 'opus'   },
+  unknown:      { low: 'sonnet', medium: 'sonnet', high: 'opus'   },
+};
+
 const DEFAULTS = {
   // Default model: where routing starts. Tasks go up or down from here based on complexity.
   // 'haiku'  — start on haiku, upgrade for complex tasks (max savings)
@@ -22,9 +45,14 @@ const DEFAULTS = {
   // Dashboard port. null = use default 6099.
   dashboard_port: null,
 
-  // Force model override: when set, bypasses all routing logic and uses this model for every task.
-  // null = normal routing; 'haiku' | 'sonnet' | 'opus' = locked override.
+  // DEPRECATED (#95) — migrated into routing_matrix on first load. Still read as
+  // a shim for existing configs; remove after 1–2 releases.
   force_model: null,
+
+  // Routing matrix: per-(family × complexity) model choice. When a cell is set,
+  // the hook applies it instead of the classifier's recommendation. The dashboard
+  // edits this directly. null means "use DEFAULT_MATRIX".
+  routing_matrix: null,
 
   // How many days of event history to keep. Older JSONL files are pruned on dashboard load.
   history_days: 14,
@@ -70,9 +98,52 @@ function migrate(user) {
     else if (pref <= 75) user.default_model = 'sonnet';
     else user.default_model = 'opus';
   }
+  // force_model → routing_matrix (#95): seed every cell to the forced model,
+  // then clear force_model so it doesn't fight the matrix on subsequent reads.
+  if (user.force_model && !user.routing_matrix) {
+    const m = {};
+    for (const f of FAMILIES) {
+      m[f] = { low: user.force_model, medium: user.force_model, high: user.force_model };
+    }
+    user.routing_matrix = m;
+    user._force_model_migrated = user.force_model;
+    user.force_model = null;
+  }
   // Strip legacy keys so they don't appear in the runtime config
   delete user.model_floor;
   return user;
+}
+
+/**
+ * Look up the model for a classified (family, complexity). Returns the
+ * configured cell, falling back to DEFAULT_MATRIX, then to 'sonnet' as a
+ * last resort.
+ */
+function getMatrixCell(family, complexity) {
+  const cfg = read();
+  const fam = FAMILIES.includes(family) ? family : 'unknown';
+  const cx = COMPLEXITIES.includes(complexity) ? complexity : 'medium';
+  const matrix = cfg.routing_matrix || {};
+  const row = matrix[fam] || DEFAULT_MATRIX[fam] || DEFAULT_MATRIX.unknown;
+  return row[cx] || DEFAULT_MATRIX[fam][cx] || 'sonnet';
+}
+
+/** Merge a partial matrix update into the stored config. Cells not provided stay unchanged. */
+function updateMatrix(partial) {
+  const cfg = read();
+  const current = cfg.routing_matrix || {};
+  const next = {};
+  for (const f of FAMILIES) {
+    const existing = current[f] || DEFAULT_MATRIX[f];
+    const incoming = partial?.[f] || {};
+    next[f] = {
+      low:    incoming.low    || existing.low,
+      medium: incoming.medium || existing.medium,
+      high:   incoming.high   || existing.high,
+    };
+  }
+  set('routing_matrix', next);
+  return next;
 }
 
 /** Read config, merging user values over defaults. */
@@ -106,4 +177,8 @@ function clearCache() {
   _cache = null;
 }
 
-module.exports = { DEFAULTS, read, set, clearCache, configPath };
+module.exports = {
+  DEFAULTS, FAMILIES, COMPLEXITIES, DEFAULT_MATRIX,
+  read, set, clearCache, configPath,
+  getMatrixCell, updateMatrix,
+};

--- a/src/learner.js
+++ b/src/learner.js
@@ -271,7 +271,51 @@ function getLearningStats() {
   };
 }
 
+/**
+ * Build a suggested routing matrix from accumulated outcome data (#95).
+ *
+ * Strategy per family row: find the cheapest model (haiku < sonnet < opus) whose
+ * weighted success rate is ≥ 0.95 across ≥ MIN_SUGGEST samples. Apply that model
+ * to all three complexity columns for the family. If no model meets the bar,
+ * fall back to the provided defaultMatrix for that family.
+ *
+ * Complexity-aware suggestions are a future improvement — the current learner
+ * doesn't bucket by complexity, so all three columns get the same suggestion
+ * for a given family until the outcome schema is extended.
+ *
+ * @param {object} defaultMatrix — fallback matrix (from config.DEFAULT_MATRIX)
+ * @returns {object} matrix of shape { family: { low, medium, high } }
+ */
+function suggestMatrix(defaultMatrix) {
+  const MIN_SUGGEST = 10;        // floor for meaningful suggestion
+  const MIN_RATE = 0.95;         // "very high success" threshold
+  const TIERS = ['haiku', 'sonnet', 'opus'];
+
+  const data = buildLearningData();
+  const byFamily = {};
+  for (const entry of Object.values(data.byFamilyModel)) {
+    if (!byFamily[entry.family]) byFamily[entry.family] = {};
+    byFamily[entry.family][entry.model] = entry;
+  }
+
+  const suggested = {};
+  for (const [family, defaults] of Object.entries(defaultMatrix)) {
+    let pick = null;
+    for (const tier of TIERS) {
+      const e = byFamily[family]?.[tier];
+      if (e && e.samples >= MIN_SUGGEST && e.weightedRate >= MIN_RATE) {
+        pick = tier;
+        break; // cheapest first — take it
+      }
+    }
+    suggested[family] = pick
+      ? { low: pick, medium: pick, high: pick }
+      : { ...defaults };
+  }
+  return suggested;
+}
+
 /** Clear the cache (e.g. after new events are recorded). */
 function clearCache() { _cache = null; _cacheTime = 0; }
 
-module.exports = { buildLearningData, getAdjustment, getLearningStats, clearCache };
+module.exports = { buildLearningData, getAdjustment, getLearningStats, suggestMatrix, clearCache };

--- a/src/server.js
+++ b/src/server.js
@@ -522,6 +522,61 @@ const server = http.createServer((req, res) => {
     }
   }
 
+  if (req.url === '/api/matrix' && req.method === 'GET') {
+    const cfg = config.read();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      matrix: cfg.routing_matrix || config.DEFAULT_MATRIX,
+      defaults: config.DEFAULT_MATRIX,
+      families: config.FAMILIES,
+      complexities: config.COMPLEXITIES,
+      isUsingDefaults: !cfg.routing_matrix,
+      learnerStats: getLearningStats().adjustments,
+      migratedFromForceModel: cfg._force_model_migrated || null,
+    }));
+    return;
+  }
+
+  if (req.url === '/api/matrix' && (req.method === 'PUT' || req.method === 'POST')) {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const { matrix } = JSON.parse(body);
+        if (!matrix || typeof matrix !== 'object') throw new Error('matrix object required');
+        const validModels = new Set(['haiku', 'sonnet', 'opus']);
+        for (const family of Object.keys(matrix)) {
+          if (!config.FAMILIES.includes(family)) throw new Error(`unknown family: ${family}`);
+          for (const cx of Object.keys(matrix[family] || {})) {
+            if (!config.COMPLEXITIES.includes(cx)) throw new Error(`unknown complexity: ${cx}`);
+            if (!validModels.has(matrix[family][cx])) throw new Error(`invalid model: ${matrix[family][cx]}`);
+          }
+        }
+        const next = config.updateMatrix(matrix);
+        config.clearCache();
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ matrix: next }));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+      }
+    });
+    return;
+  }
+
+  if (req.url === '/api/matrix/suggest' && req.method === 'GET') {
+    try {
+      const { suggestMatrix } = require('./learner');
+      const suggested = suggestMatrix(config.DEFAULT_MATRIX);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ matrix: suggested }));
+    } catch (err) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: err.message }));
+    }
+    return;
+  }
+
   if (req.url === '/api/hooks/status' && req.method === 'GET') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ enabled: getHooksStatus() }));

--- a/test/routing-matrix.test.js
+++ b/test/routing-matrix.test.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Tests for the routing matrix (#95).
+ * Run: node test/routing-matrix.test.js
+ */
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-matrix-'));
+process.env.TOKEN_COACH_HOME = TMP;
+
+const config = require('../src/config');
+const { suggestMatrix } = require('../src/learner');
+const events = require('../src/events');
+const learner = require('../src/learner');
+
+const results = [];
+function test(name, fn) {
+  try {
+    fn();
+    results.push({ name, ok: true });
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    results.push({ name, ok: false, err });
+    console.log(`  FAIL ${name}`);
+    console.log(`       ${err.stack || err.message}`);
+  }
+}
+
+function resetConfig(obj = {}) {
+  fs.writeFileSync(config.configPath(), JSON.stringify(obj, null, 2));
+  config.clearCache();
+  learner.clearCache();
+}
+
+function seedOutcomes(family, model, count, rate = 1.0) {
+  for (let i = 0; i < count; i++) {
+    events.logEvent('outcome', {
+      session_id: `s-${family}-${model}-${i}`,
+      family,
+      model,
+      turn_success: Math.random() < rate,
+      was_escalated: false,
+    });
+  }
+  learner.clearCache();
+}
+
+console.log('routing-matrix tests\n');
+
+// ─────────────────────────────────────────────────────────────
+// Lookup correctness
+// ─────────────────────────────────────────────────────────────
+
+test('getMatrixCell returns built-in default when no user matrix', () => {
+  resetConfig();
+  assert.strictEqual(config.getMatrixCell('search_read', 'low'), 'haiku');
+  assert.strictEqual(config.getMatrixCell('debug', 'high'), 'opus');
+  assert.strictEqual(config.getMatrixCell('architecture', 'low'), 'opus');
+});
+
+test('getMatrixCell falls back to unknown row for unrecognized family', () => {
+  resetConfig();
+  // unknown defaults: sonnet/sonnet/opus
+  assert.strictEqual(config.getMatrixCell('nonexistent', 'low'), 'sonnet');
+  assert.strictEqual(config.getMatrixCell('nonexistent', 'high'), 'opus');
+});
+
+test('getMatrixCell normalizes unknown complexity to medium', () => {
+  resetConfig();
+  // search_read/medium default is 'haiku'
+  assert.strictEqual(config.getMatrixCell('search_read', 'huge'), 'haiku');
+});
+
+test('updateMatrix persists and is returned by getMatrixCell', () => {
+  resetConfig();
+  config.updateMatrix({ code_edit: { low: 'haiku', medium: 'sonnet', high: 'opus' } });
+  assert.strictEqual(config.getMatrixCell('code_edit', 'low'), 'haiku');
+  assert.strictEqual(config.getMatrixCell('code_edit', 'high'), 'opus');
+  // Other families unchanged
+  assert.strictEqual(config.getMatrixCell('debug', 'high'), 'opus');
+});
+
+test('updateMatrix merges partial updates without blanking other cells', () => {
+  resetConfig();
+  config.updateMatrix({ code_edit: { low: 'haiku', medium: 'sonnet', high: 'opus' } });
+  config.updateMatrix({ code_edit: { low: 'opus' } });
+  assert.strictEqual(config.getMatrixCell('code_edit', 'low'), 'opus');
+  assert.strictEqual(config.getMatrixCell('code_edit', 'medium'), 'sonnet');
+  assert.strictEqual(config.getMatrixCell('code_edit', 'high'), 'opus');
+});
+
+// ─────────────────────────────────────────────────────────────
+// force_model migration
+// ─────────────────────────────────────────────────────────────
+
+test('force_model seeds every cell on first migrate', () => {
+  resetConfig({ force_model: 'haiku' });
+  const cfg = config.read();
+  assert.strictEqual(cfg.force_model, null, 'force_model should be cleared after migration');
+  assert.strictEqual(cfg._force_model_migrated, 'haiku', 'migration marker should record the forced value');
+  for (const f of config.FAMILIES) {
+    for (const cx of config.COMPLEXITIES) {
+      assert.strictEqual(config.getMatrixCell(f, cx), 'haiku', `${f}/${cx} should be seeded to haiku`);
+    }
+  }
+});
+
+test('force_model migration does not overwrite existing matrix', () => {
+  resetConfig({
+    force_model: 'opus',
+    routing_matrix: { code_edit: { low: 'haiku', medium: 'haiku', high: 'haiku' } },
+  });
+  const cfg = config.read();
+  assert.strictEqual(cfg.force_model, 'opus', 'force_model should NOT be touched when matrix already exists');
+  assert.strictEqual(config.getMatrixCell('code_edit', 'low'), 'haiku');
+});
+
+// ─────────────────────────────────────────────────────────────
+// suggestMatrix (learner-derived)
+// ─────────────────────────────────────────────────────────────
+
+test('suggestMatrix falls back to DEFAULT_MATRIX when no learner data', () => {
+  resetConfig();
+  const m = suggestMatrix(config.DEFAULT_MATRIX);
+  assert.strictEqual(m.code_edit.medium, config.DEFAULT_MATRIX.code_edit.medium);
+  assert.strictEqual(m.search_read.low,   config.DEFAULT_MATRIX.search_read.low);
+});
+
+test('suggestMatrix picks cheapest viable model when learner data supports it', () => {
+  resetConfig();
+  // haiku succeeds 100% on search_read over 20 outcomes
+  seedOutcomes('search_read', 'haiku', 20, 1.0);
+  const m = suggestMatrix(config.DEFAULT_MATRIX);
+  assert.strictEqual(m.search_read.low, 'haiku');
+  assert.strictEqual(m.search_read.medium, 'haiku');
+  assert.strictEqual(m.search_read.high, 'haiku');
+});
+
+test('suggestMatrix skips families with insufficient samples', () => {
+  resetConfig();
+  // Only 5 outcomes — below MIN_SUGGEST threshold of 10
+  seedOutcomes('plan', 'haiku', 5, 1.0);
+  const m = suggestMatrix(config.DEFAULT_MATRIX);
+  assert.strictEqual(m.plan.medium, config.DEFAULT_MATRIX.plan.medium);
+});
+
+const passed = results.filter(r => r.ok).length;
+const failed = results.length - passed;
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed) process.exit(1);


### PR DESCRIPTION
Closes #95.

## What this does

Introduces a per-`(family × complexity)` routing matrix edited from the dashboard. The matrix is the primary routing source; the classifier still runs but the matrix cell trumps its recommendation when set. `force_model` is absorbed as a migration shim.

## Files

- **`src/config.js`** — new `FAMILIES`, `COMPLEXITIES`, `DEFAULT_MATRIX`, `getMatrixCell()`, `updateMatrix()`. Migrates `force_model` → seeded matrix on first load.
- **`src/learner.js`** — `suggestMatrix()` returns a learner-derived matrix using the ≥95% success / ≥10 outcomes heuristic. Falls back to `DEFAULT_MATRIX` per family when data is insufficient.
- **`bin/hook-router.js`** — matrix override runs right after classifier; tags reason with `[matrix]` so UI shows why recommendation differs.
- **`src/server.js`** — `GET/PUT /api/matrix` + `GET /api/matrix/suggest` endpoints.
- **`public/index.html`** — "Routing matrix" card: 10×3 select grid, Save, Reset-to-suggested, Set-all-to-X, hover tooltips with learner stats.
- **`test/routing-matrix.test.js`** — 10 tests (cell lookup, unknown family/complexity fallback, partial merges, force_model migration happy path + no-op, suggester fallback, suggester picking cheapest viable, sample floor).

## Verification

```
$ for f in test/*.test.js; do node "$f" | tail -1; done
6/6 passed, 0 failed
9/9 passed, 0 failed
10/10 passed, 0 failed
9/9 passed, 0 failed
10 passed, 0 failed
```

End-to-end hook simulation: before matrix override, `search_read/low` routes to haiku; after setting `search_read/low = opus` via `/api/matrix`, the same prompt routes to opus with reason `[matrix] dashboard rule: search_read/low → opus`.

## Test plan (manual)

- [ ] Open dashboard, scroll to "Routing matrix" card
- [ ] Verify 10-row × 3-column grid renders with the defaults
- [ ] Hover a cell → see learner stat tooltip (e.g. "haiku: 99% success · 33 outcomes")
- [ ] Change `search_read/low` to `opus`, click Save → status "Saved. Takes effect on next prompt."
- [ ] Send a prompt like "find all usages of X" → recommendation box shows `OPUS search_read (low)` with `[matrix]` tag
- [ ] Click "Reset to suggested" → cells repopulate from learner data; click Save
- [ ] Pick `haiku` in "Set all to" → every cell flips to haiku; click Save (equivalent to old `force_model=haiku`)
- [ ] Set `force_model=opus` in `~/.token-coach/config.json` and reload dashboard → see migration banner, all cells seeded to opus

## Scope / follow-ups (intentionally out)

- `force_model` still works as a migration shim; removal is a later issue once users have migrated
- Learner doesn't yet bucket by complexity → suggester sets all 3 columns to the same model per family; true 2D suggestions need an outcome-schema extension
- Per-prompt override (#TBD), project-specific matrices (#TBD), capture+replay (#TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)