### PR TITLE
feat(#97): remove default_model + force_model; add matrix preset dropdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ node bin/cli.js uninstall         # Remove hooks, stop dashboard, clean up
 
 # Config
 node bin/cli.js config                          # View all
-node bin/cli.js config routing_preference 35    # Cost preference 0-100
+node bin/cli.js dashboard                        # Edit routing matrix (primary routing control)
 node bin/cli.js config daily_alert 5            # Budget alert threshold
 node bin/cli.js config daily_cap 20             # Budget cap
 

--- a/README.md
+++ b/README.md
@@ -242,13 +242,14 @@ node bin/cli.js dashboard    # Start the web dashboard (uses configured port, de
 
 ```bash
 node bin/cli.js config                          # View all settings
-node bin/cli.js config routing_preference 20    # Set cost preference (0-100)
 node bin/cli.js config daily_alert 5            # Warn when daily spend hits $5
 node bin/cli.js config daily_cap 20             # Alert when daily spend hits $20
 node bin/cli.js config dashboard_port 8080      # Change dashboard port
 node bin/cli.js config read_dedupe false        # Disable PreToolUse Read blocking
 node bin/cli.js config session_start_map false  # Disable SessionStart project-map injection
 ```
+
+Routing is controlled by the matrix on the dashboard. Pick a preset (Balanced / Coder / Reader / Budget / Max accuracy) or edit individual cells. The old `default_model` and `force_model` keys are deprecated — `force_model` auto-migrates into the matrix on first load.
 
 **Task execution (advanced)**
 
@@ -267,20 +268,19 @@ When executing, Token Tracker snapshots files before and after, spawns `claude -
 
 ---
 
-### Routing preference
+### Routing presets
 
-Control the cost vs. quality tradeoff with a number from 0 to 100:
+The dashboard's "Routing matrix" card is the primary routing control. Pick a named preset, then tweak individual cells if you want surgical adjustments.
 
-```bash
-node bin/cli.js config routing_preference 35
-```
+| Preset | Behavior |
+|---|---|
+| **Balanced** (default) | Safe defaults — haiku for simple reads, sonnet for most edits, opus for architecture and high-complexity multi-file work |
+| **Coder** | Opus-heavy on code_edit / multi_file / debug / architecture; haiku only for simple searches |
+| **Reader** | Haiku-heavy on search / review / question / command; opus reserved for architecture |
+| **Budget** | Haiku everywhere possible; sonnet for debug/architecture mid-tier; opus only for architecture/high |
+| **Max accuracy** | Opus for every cell — equivalent to the old `force_model=opus` |
 
-| Range | Mode | Behavior |
-|-------|------|----------|
-| 0-25 | Max savings | Aggressively uses haiku and sonnet. Opus only for architecture. |
-| 26-50 | Cost-conscious (default: 35) | Sonnet-heavy. Opus for architecture and multi-file only. |
-| 51-75 | Balanced | Opus for complex debug, review, and planning tasks. |
-| 76-100 | Max quality | Opus for anything medium complexity or higher. |
+You can also hover any cell in the grid to see your own historical success rate for that family × model (from the adaptive learner).
 
 ---
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -216,11 +216,10 @@ function handleConfig(args) {
       console.log(`  ${k}: ${JSON.stringify(v)}${label}`);
     }
     console.log('\n  Set a value: claude-tokens config <key> <value>');
-    console.log('  Example: claude-tokens config default_model haiku\n');
-    console.log('  Default model (routing starts here, adjusts up or down by task complexity):');
-    console.log('    haiku  — Start on haiku, upgrade for complex tasks (max savings)');
-    console.log('    sonnet — Start on sonnet (default), haiku for simple, opus for complex');
-    console.log('    opus   — Always use opus, no downgrading\n');
+    console.log('  Example: claude-tokens config dashboard_port 7000\n');
+    console.log('  Routing is controlled by the matrix on the dashboard — open it with');
+    console.log('  `claude-tokens dashboard` and pick a preset (Balanced / Coder / Reader /');
+    console.log('  Budget / Max accuracy), or edit individual cells.\n');
     return;
   }
 
@@ -253,36 +252,12 @@ function handleConfig(args) {
     return;
   }
 
-  // Validate default_model (also accept model_floor as legacy alias)
-  if (key === 'default_model' || key === 'model_floor') {
-    const valid = ['haiku', 'sonnet', 'opus'];
-    if (!valid.includes(value)) {
-      console.error(`  Error: default_model must be one of: ${valid.join(', ')}`);
-      process.exit(1);
-    }
-    config.set('default_model', value);
-    const labels = {
-      haiku: 'haiku-first — routing starts here, upgrades for complex tasks (max savings)',
-      sonnet: 'sonnet-first — routing starts here, adjusts up or down (default)',
-      opus: 'opus-first — always opus, no downgrading',
-    };
-    console.log(`\n  ✓ default_model set to ${value} — ${labels[value]}\n`);
-    return;
-  }
-
-  // Legacy: routing_preference — map to default_model
-  if ((key === 'routing_preference' || key === '--preference') && typeof parsed === 'number') {
-    if (parsed < 0 || parsed > 100) {
-      console.error('  Error: routing_preference must be 0-100');
-      process.exit(1);
-    }
-    config.set('routing_preference', parsed);
-    const floor = parsed <= 25 ? 'haiku' : parsed <= 75 ? 'sonnet' : 'opus';
-    config.set('default_model', floor);
-    const label = parsed <= 25 ? 'max savings' : parsed <= 50 ? 'cost-conscious' : parsed <= 75 ? 'balanced' : 'max quality';
-    console.log(`\n  ✓ routing_preference set to ${parsed} (${label})`);
-    console.log(`  ✓ default_model set to ${floor}\n`);
-    return;
+  // Deprecated keys (#97) — route users to the dashboard matrix.
+  if (['default_model', 'model_floor', 'force_model', 'routing_preference', '--preference'].includes(key)) {
+    console.error(`  Error: "${key}" is deprecated. Routing is now controlled by the matrix on the dashboard.`);
+    console.error(`  Open it with: claude-tokens dashboard`);
+    console.error(`  Pick a preset (Budget / Balanced / Coder / Reader / Max accuracy) or edit individual cells.\n`);
+    process.exit(1);
   }
 
   config.set(key, parsed);

--- a/bin/hook-router.js
+++ b/bin/hook-router.js
@@ -176,7 +176,6 @@ function handleUserPromptSubmit(input) {
     classification,
     recommended_model: recommendation.model,
     base_model: recommendation.baseModel,
-    default_model: recommendation.default_model,
     recommended_reason: recommendation.reasons.join('; '),
     actual_model: null,
     was_delegated: null,
@@ -243,9 +242,6 @@ function handleUserPromptSubmit(input) {
     warnings.push(`${warnColor}! Long prompt (${prompt.length} chars) classified as unknown -- vague prompts waste tokens. Be specific: file paths, line numbers, exact changes.${reset}`);
   }
 
-  // Override detection — force_model bypasses routing
-  const isOverride = recommendation.reasons.some(r => r.startsWith('[override]'));
-
   // Learning signal detection — three variants with different urgency
   const learnChanged  = recommendation.reasons.filter(r => r.startsWith('[learned]') && !r.startsWith('[learned:'));
   const learnTip      = recommendation.reasons.filter(r => r.startsWith('[learned:tip]'));
@@ -269,16 +265,11 @@ function handleUserPromptSubmit(input) {
     learnLine = `  ${learnConfirmColor}✓ learned:${reset} ${muted}${text}${reset}`;
   }
 
-  const overrideLine = isOverride
-    ? `  ${alertColor}\x1b[1m⚠ OVERRIDE ACTIVE${reset}${alertColor} — force_model=${recommendation.model}, routing bypassed${reset}`
-    : null;
-
   const lines = [
     `${gray}- - - - - - - - - - - - - - - - - - - -${reset}`,
     `${amber}${bold}TOKEN COACH${reset}  ${gray}${classification.family} (${classification.complexity}, ${confidence} conf)${reset}`,
-    `  ${gray}model:${reset}   ${color}${recommendation.model}${reset}  ${muted}${recommendation.reasons.filter(r => !r.startsWith('[learned') && !r.startsWith('[override]')).join('; ')}${reset}`,
+    `  ${gray}model:${reset}   ${color}${recommendation.model}${reset}  ${muted}${recommendation.reasons.filter(r => !r.startsWith('[learned')).join('; ')}${reset}`,
     `  ${gray}action:${reset}  ${color}${action}${reset}`,
-    ...(overrideLine ? [overrideLine] : []),
     ...(learnLine ? [learnLine] : []),
     `  ${gray}session:${reset} ${costColor}${costStr}${reset} ${gray}(${promptCount} prompts)${reset}`,
     ...warnings,
@@ -301,12 +292,10 @@ function handleUserPromptSubmit(input) {
     ? ` [Learning: confirmed] ${learnConfirm.map(r => r.replace('[learned:confirm] ', '')).join('; ')}.`
     : '';
 
-  const overrideNote = isOverride ? ` OVERRIDE ACTIVE: force_model=${recommendation.model} set in config — routing bypassed.` : '';
-
   const ctx = [
     `[claude-token-tracker] Task classified: ${classification.family} (${classification.complexity} complexity, ${confidence} confidence).`,
     `Recommended model: ${recommendation.model.toUpperCase()}.`,
-    `Reason: ${recommendation.reasons.filter(r => !r.startsWith('[learned') && !r.startsWith('[override]')).join('; ') || 'routing bypassed by force_model'}.${learnNote}${overrideNote}`,
+    `Reason: ${recommendation.reasons.filter(r => !r.startsWith('[learned')).join('; ') || 'routing baseline'}.${learnNote}`,
     `Session: ${costStr} (${promptCount} prompts).${warningLines}`,
   ];
 

--- a/public/index.html
+++ b/public/index.html
@@ -515,21 +515,17 @@ function renderMatrix(state) {
     </table>
     </div>
     <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center">
-      <button id="matrix-save" class="btn" style="padding:6px 14px;background:var(--fg);color:var(--bg);border:none;border-radius:4px;font-size:12px;cursor:pointer">Save matrix</button>
-      <button id="matrix-reset" class="btn" style="padding:6px 14px;background:transparent;color:var(--fg);border:1px solid var(--border);border-radius:4px;font-size:12px;cursor:pointer">Reset to suggested (from learner data)</button>
-      <span style="font-size:11px;color:var(--dim);margin-left:4px">Set all to:</span>
-      <select id="matrix-set-all" style="font-family:var(--mono);font-size:11px;padding:4px 6px;border:1px solid var(--border);background:var(--card);color:var(--fg);border-radius:4px">
-        <option value="">—</option>
-        <option value="haiku">haiku (equivalent to force_model=haiku)</option>
-        <option value="sonnet">sonnet</option>
-        <option value="opus">opus</option>
+      <span style="font-size:11px;color:var(--dim)">Preset:</span>
+      <select id="matrix-preset" style="font-family:var(--mono);font-size:11px;padding:4px 6px;border:1px solid var(--border);background:var(--card);color:var(--fg);border-radius:4px">
+        <option value="">— choose —</option>
+        ${Object.keys(state.presets || {}).map(name => `<option value="${esc(name)}">${esc(name)}</option>`).join('')}
       </select>
-      <span id="matrix-status" style="font-size:11px;color:var(--dim);margin-left:auto"></span>
+      <button id="matrix-reset" class="btn" style="padding:6px 12px;background:transparent;color:var(--fg);border:1px solid var(--border);border-radius:4px;font-size:12px;cursor:pointer" title="Suggest cells based on your own learner success rates">Suggest from learner data</button>
+      <button id="matrix-save" class="btn" style="padding:6px 14px;background:var(--fg);color:var(--bg);border:none;border-radius:4px;font-size:12px;cursor:pointer;margin-left:auto">Save matrix</button>
+      <span id="matrix-status" style="font-size:11px;color:var(--dim);width:100%;text-align:right;margin-top:4px"></span>
     </div>
-    <div style="font-size:10px;color:var(--dim);margin-top:10px">
-      Hover any cell to see learner success rate.
-      Matrix overrides the classifier — it's the primary routing source.
-      <code>force_model</code> is deprecated; setting every cell to the same model achieves the same result.
+    <div style="font-size:10px;color:var(--dim);margin-top:10px;line-height:1.5">
+      <strong style="color:var(--fg)">Presets</strong> are one-click starting points — pick one, tweak individual cells, then Save. <strong style="color:var(--fg)">Balanced</strong> is the default. <strong style="color:var(--fg)">Coder</strong> leans opus on code/debug. <strong style="color:var(--fg)">Reader</strong> and <strong style="color:var(--fg)">Budget</strong> lean haiku. <strong style="color:var(--fg)">Max accuracy</strong> sets every cell to opus. Hover any cell to see your historical success rate for that family × model.
     </div>
   `;
 }
@@ -585,11 +581,17 @@ document.addEventListener('click', async (e) => {
 });
 
 document.addEventListener('change', (e) => {
-  if (e.target?.id === 'matrix-set-all' && e.target.value) {
-    const m = e.target.value;
-    for (const sel of document.querySelectorAll('.matrix-cell')) sel.value = m;
+  if (e.target?.id === 'matrix-preset' && e.target.value) {
+    const presetName = e.target.value;
+    const matrix = MATRIX_STATE?.presets?.[presetName];
+    if (!matrix) return;
+    for (const sel of document.querySelectorAll('.matrix-cell')) {
+      const f = sel.dataset.family;
+      const cx = sel.dataset.cx;
+      if (matrix[f]?.[cx]) sel.value = matrix[f][cx];
+    }
     e.target.value = '';
-    matrixStatus(`All cells set to ${m}. Click "Save matrix" to persist.`, 'var(--accent)');
+    matrixStatus(`Loaded preset: ${presetName}. Click "Save matrix" to persist.`, 'var(--accent)');
   }
 });
 
@@ -669,25 +671,10 @@ function buildHTML() {
 
     <div class="card anim d1" style="margin-bottom:12px">
       <div class="card-hd">
-        <h2>Default model</h2>
-        <span class="ct" id="v-floor-label">${D.config?.default_model || D.config?.model_floor || 'sonnet'}</span>
+        <h2>Settings</h2>
       </div>
-      <div style="font-size:12px;color:var(--dim);margin-bottom:10px;line-height:1.5">Routing starts here and adjusts up or down based on task complexity. Simple tasks go lower, complex tasks go higher.</div>
-      <div class="floor-row" id="v-floor-row">
-        ${renderFloorSelector(D.config?.default_model || D.config?.model_floor || 'sonnet')}
-      </div>
-      <div id="v-floor-warning">${renderFloorWarning(D)}</div>
-      <div id="v-floor-error" style="display:none;font-size:12px;color:#c0392b;margin-top:8px;padding:6px 8px;background:rgba(192,57,43,0.08);border-radius:4px"></div>
-      <div style="margin-top:14px;padding-top:12px;border-top:1px solid var(--border)">
-        <div style="font-size:12px;font-weight:600;color:var(--fg);margin-bottom:4px">Force override</div>
-        <div style="font-size:11px;color:var(--dim);margin-bottom:8px;line-height:1.4">Lock a specific model regardless of TC's routing logic. Use when you want full control — e.g., force Opus while debugging.</div>
-        <div class="floor-row" id="v-override-row">
-          ${renderOverrideSelector(D.config?.force_model || null)}
-        </div>
-        <div id="v-override-warn" style="display:${D.config?.force_model ? '' : 'none'};margin-top:8px;font-size:11px;color:#e67e22;padding:5px 8px;background:rgba(230,126,34,0.1);border-radius:4px">⚠ Override active — TC routing is bypassed. All tasks will use <strong id="v-override-model">${D.config?.force_model || ''}</strong>.</div>
-        <div id="v-override-error" style="display:none;font-size:12px;color:#c0392b;margin-top:8px;padding:6px 8px;background:rgba(192,57,43,0.08);border-radius:4px"></div>
-      </div>
-      <div style="margin-top:14px;padding-top:12px;border-top:1px solid var(--separator)">
+      <div style="font-size:12px;color:var(--dim);margin-bottom:10px;line-height:1.5">Routing is controlled by the <a href="#v-matrix-card" style="color:var(--accent)">Routing matrix</a> below. Pick a preset (Balanced / Coder / Reader / Budget / Max accuracy) to change how every task is routed.</div>
+      <div style="padding-top:12px;border-top:1px solid var(--separator)">
         <div style="display:flex;justify-content:space-between;align-items:center;gap:12px">
           <div>
             <div style="font-size:13px;font-weight:500">History retention</div>
@@ -1044,78 +1031,6 @@ function renderCostSinceInstall(D) {
   </div>`;
 
   return html;
-}
-
-function renderFloorWarning(D) {
-  // Session model display removed — Claude Code's /config model selector doesn't reliably persist
-  return '';
-}
-
-function renderFloorSelector(current) {
-  const floors = [
-    { id: 'haiku', label: 'Haiku-first', desc: 'Start on haiku, only upgrade when needed' },
-    { id: 'sonnet', label: 'Sonnet-first', desc: 'Start on sonnet, upgrade to opus for complex work' },
-    { id: 'opus', label: 'Opus-first', desc: 'Everything runs on opus, no routing' },
-  ];
-  return floors.map(f =>
-    `<button class="floor-btn ${f.id === current ? 'on' : ''}" onclick="setFloor('${f.id}')" aria-pressed="${f.id === current}"><strong>${f.label}</strong><span>${f.desc}</span></button>`
-  ).join('');
-}
-
-function setFloor(floor) {
-  const errEl = document.getElementById('v-floor-error');
-  if (errEl) { errEl.style.display = 'none'; errEl.textContent = ''; }
-  fetch('/api/config', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ default_model: floor }),
-  }).then(r => {
-    if (!r.ok) throw new Error('Server error ' + r.status);
-    return r.json();
-  }).then(cfg => {
-    if (DATA) DATA.config = cfg;
-    const row = document.getElementById('v-floor-row');
-    if (row) row.innerHTML = renderFloorSelector(floor);
-    const label = document.getElementById('v-floor-label');
-    if (label) label.textContent = floor;
-  }).catch(err => {
-    if (errEl) { errEl.textContent = 'Failed to save: ' + err.message; errEl.style.display = ''; }
-  });
-}
-
-function renderOverrideSelector(current) {
-  const opts = [
-    { id: null, label: 'Off', desc: 'TC routes normally' },
-    { id: 'haiku', label: 'Force Haiku', desc: 'Lock to haiku for every task' },
-    { id: 'sonnet', label: 'Force Sonnet', desc: 'Lock to sonnet for every task' },
-    { id: 'opus', label: 'Force Opus', desc: 'Lock to opus — routing bypassed' },
-  ];
-  return opts.map(o =>
-    `<button class="floor-btn ${o.id === current ? 'on' : ''}" onclick="setOverride(${o.id === null ? 'null' : "'" + o.id + "'"})" aria-pressed="${o.id === current}"><strong>${o.label}</strong><span>${o.desc}</span></button>`
-  ).join('');
-}
-
-function setOverride(model) {
-  const errEl = document.getElementById('v-override-error');
-  if (errEl) { errEl.style.display = 'none'; errEl.textContent = ''; }
-  fetch('/api/config', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ force_model: model }),
-  }).then(r => {
-    if (!r.ok) throw new Error('Server error ' + r.status);
-    return r.json();
-  }).then(cfg => {
-    if (DATA) DATA.config = cfg;
-    const row = document.getElementById('v-override-row');
-    if (row) row.innerHTML = renderOverrideSelector(model);
-    const warn = document.getElementById('v-override-warn');
-    if (warn) { warn.style.display = model ? '' : 'none'; }
-    const modelSpan = document.getElementById('v-override-model');
-    if (modelSpan) modelSpan.textContent = model || '';
-  }).catch(err => {
-    if (errEl) { errEl.textContent = 'Failed to save: ' + err.message; errEl.style.display = ''; }
-  });
 }
 
 function saveHistoryDays(val) {

--- a/src/config.js
+++ b/src/config.js
@@ -12,9 +12,8 @@ const FAMILIES = [
 ];
 const COMPLEXITIES = ['low', 'medium', 'high'];
 
-// Hardcoded safe defaults for the routing matrix (#95). Used when the user has no
-// per-cell preference and learner data is insufficient to suggest one. Roughly
-// mirrors what the classifier+escalation path would pick today.
+// Safe defaults for the routing matrix. Used when the user hasn't customized it.
+// Roughly mirrors what the classifier+escalation path would have picked.
 const DEFAULT_MATRIX = {
   search_read:  { low: 'haiku',  medium: 'haiku',  high: 'sonnet' },
   code_edit:    { low: 'sonnet', medium: 'sonnet', high: 'opus'   },
@@ -28,14 +27,55 @@ const DEFAULT_MATRIX = {
   unknown:      { low: 'sonnet', medium: 'sonnet', high: 'opus'   },
 };
 
-const DEFAULTS = {
-  // Default model: where routing starts. Tasks go up or down from here based on complexity.
-  // 'haiku'  — start on haiku, upgrade for complex tasks (max savings)
-  // 'sonnet' — start on sonnet, haiku for simple tasks, opus for complex (default)
-  // 'opus'   — everything runs on opus, no downgrading
-  default_model: 'sonnet',
+// Named presets for the matrix (#97). Dashboard exposes these as a dropdown so
+// new users get a one-click on-ramp instead of 30 blank cells.
+const PRESETS = {
+  Balanced: DEFAULT_MATRIX,
+  Coder: {
+    search_read:  { low: 'haiku',  medium: 'sonnet', high: 'sonnet' },
+    code_edit:    { low: 'sonnet', medium: 'opus',   high: 'opus'   },
+    multi_file:   { low: 'opus',   medium: 'opus',   high: 'opus'   },
+    debug:        { low: 'opus',   medium: 'opus',   high: 'opus'   },
+    review:       { low: 'sonnet', medium: 'sonnet', high: 'opus'   },
+    plan:         { low: 'sonnet', medium: 'opus',   high: 'opus'   },
+    architecture: { low: 'opus',   medium: 'opus',   high: 'opus'   },
+    command:      { low: 'haiku',  medium: 'sonnet', high: 'sonnet' },
+    question:     { low: 'sonnet', medium: 'sonnet', high: 'opus'   },
+    unknown:      { low: 'sonnet', medium: 'opus',   high: 'opus'   },
+  },
+  Reader: {
+    search_read:  { low: 'haiku',  medium: 'haiku',  high: 'haiku'  },
+    code_edit:    { low: 'haiku',  medium: 'sonnet', high: 'sonnet' },
+    multi_file:   { low: 'sonnet', medium: 'sonnet', high: 'opus'   },
+    debug:        { low: 'sonnet', medium: 'sonnet', high: 'opus'   },
+    review:       { low: 'haiku',  medium: 'haiku',  high: 'sonnet' },
+    plan:         { low: 'haiku',  medium: 'sonnet', high: 'sonnet' },
+    architecture: { low: 'sonnet', medium: 'opus',   high: 'opus'   },
+    command:      { low: 'haiku',  medium: 'haiku',  high: 'sonnet' },
+    question:     { low: 'haiku',  medium: 'haiku',  high: 'sonnet' },
+    unknown:      { low: 'haiku',  medium: 'sonnet', high: 'sonnet' },
+  },
+  Budget: {
+    search_read:  { low: 'haiku',  medium: 'haiku',  high: 'haiku'  },
+    code_edit:    { low: 'haiku',  medium: 'haiku',  high: 'sonnet' },
+    multi_file:   { low: 'haiku',  medium: 'sonnet', high: 'sonnet' },
+    debug:        { low: 'haiku',  medium: 'sonnet', high: 'sonnet' },
+    review:       { low: 'haiku',  medium: 'haiku',  high: 'haiku'  },
+    plan:         { low: 'haiku',  medium: 'sonnet', high: 'sonnet' },
+    architecture: { low: 'sonnet', medium: 'sonnet', high: 'opus'   },
+    command:      { low: 'haiku',  medium: 'haiku',  high: 'sonnet' },
+    question:     { low: 'haiku',  medium: 'haiku',  high: 'haiku'  },
+    unknown:      { low: 'haiku',  medium: 'sonnet', high: 'sonnet' },
+  },
+  'Max accuracy': (() => {
+    const m = {};
+    for (const f of FAMILIES) m[f] = { low: 'opus', medium: 'opus', high: 'opus' };
+    return m;
+  })(),
+};
 
-  // Legacy — kept for backward compat; ignored when default_model is set explicitly.
+const DEFAULTS = {
+  // Legacy — ignored; kept so old configs don't error.
   routing_preference: 35,
 
   // Daily budget alerts (USD). null = disabled.
@@ -44,10 +84,6 @@ const DEFAULTS = {
 
   // Dashboard port. null = use default 6099.
   dashboard_port: null,
-
-  // DEPRECATED (#95) — migrated into routing_matrix on first load. Still read as
-  // a shim for existing configs; remove after 1–2 releases.
-  force_model: null,
 
   // Routing matrix: per-(family × complexity) model choice. When a cell is set,
   // the hook applies it instead of the classifier's recommendation. The dashboard
@@ -85,21 +121,10 @@ function configPath() {
   return dataHome.getConfigPath();
 }
 
-/** Migrate legacy keys to current schema. */
+/** Drop deprecated keys, migrate force_model into the matrix if needed (#97). */
 function migrate(user) {
-  // model_floor → default_model (renamed for clarity)
-  if (!user.default_model && user.model_floor) {
-    user.default_model = user.model_floor;
-  }
-  // routing_preference → default_model (oldest compat)
-  if (!user.default_model && user.routing_preference != null) {
-    const pref = user.routing_preference;
-    if (pref <= 25) user.default_model = 'haiku';
-    else if (pref <= 75) user.default_model = 'sonnet';
-    else user.default_model = 'opus';
-  }
-  // force_model → routing_matrix (#95): seed every cell to the forced model,
-  // then clear force_model so it doesn't fight the matrix on subsequent reads.
+  // force_model → routing_matrix: seed every cell to the forced model, record a
+  // one-shot migration marker so the UI can explain what happened, then drop.
   if (user.force_model && !user.routing_matrix) {
     const m = {};
     for (const f of FAMILIES) {
@@ -107,9 +132,10 @@ function migrate(user) {
     }
     user.routing_matrix = m;
     user._force_model_migrated = user.force_model;
-    user.force_model = null;
   }
-  // Strip legacy keys so they don't appear in the runtime config
+  // Silently drop deprecated keys — they no longer control routing.
+  delete user.force_model;
+  delete user.default_model;
   delete user.model_floor;
   return user;
 }
@@ -178,7 +204,7 @@ function clearCache() {
 }
 
 module.exports = {
-  DEFAULTS, FAMILIES, COMPLEXITIES, DEFAULT_MATRIX,
+  DEFAULTS, FAMILIES, COMPLEXITIES, DEFAULT_MATRIX, PRESETS,
   read, set, clearCache, configPath,
   getMatrixCell, updateMatrix,
 };

--- a/src/init-command.js
+++ b/src/init-command.js
@@ -522,14 +522,12 @@ function printInit(args = []) {
   }
 
   // Step 3: Write default config if none exists
-  const cfg = config.read();
   if (!fs.existsSync(config.configPath())) {
-    config.set('routing_preference', cfg.routing_preference);
+    config.set('history_days', config.DEFAULTS.history_days);
     ok(`Config created: ${config.configPath()}`);
-    info(`Routing preference: ${cfg.routing_preference}/100 (sonnet-heavy -- saves money)`);
+    info('Routing: matrix defaults (Balanced preset) — edit at the dashboard to customize.');
   } else {
     ok(`Config exists: ${config.configPath()}`);
-    info(`Routing preference: ${cfg.routing_preference}/100`);
   }
 
   if (portArg) {

--- a/src/insights.js
+++ b/src/insights.js
@@ -13,9 +13,8 @@ function generateInsights(data) {
 
   // ─── Primary model mismatch check ─────────────────────────
   try {
-    const config = require('./config');
     const parser = require('./parser');
-    const floor = config.read().default_model || 'sonnet';
+    const floor = 'sonnet';
     const tu = parser.readSessionTokenUsage();
     const bm = tu?.byModel || {};
     const opusCalls = bm.opus?.calls || 0;

--- a/src/router.js
+++ b/src/router.js
@@ -454,59 +454,24 @@ function upgrade(model) {
 const OPUS_FLOOR = new Set([TASK_FAMILIES.ARCHITECTURE]);
 
 /**
- * Recommend the optimal model tier based on classification and model floor.
+ * Recommend a model for a classified task.
  *
- * Default model behaviour (routing starts here, goes up or down based on complexity):
- *   'haiku'  — start on haiku, upgrade when the task genuinely needs more
- *   'sonnet' — start on sonnet (default), haiku for simple tasks, opus for complex
- *   'opus'   — everything runs on opus, no downgrading
+ * Baseline comes from user-defined capabilities (models.json) or the heuristic
+ * in getBaseRecommendation(family, complexity). Custom rules, A/B experiments,
+ * and the adaptive learner can nudge the baseline. The routing matrix applies
+ * one level up in bin/hook-router.js — this function returns the classifier's
+ * best guess, which the matrix may override.
  *
  * @param {object} classification -- from classifyTask()
- * @param {object} opts -- { default_model?: string, model_floor?: string (legacy), preference?: number (legacy) }
  */
-function recommendModel(classification, opts = {}) {
+function recommendModel(classification) {
   const { family, complexity, customModel } = classification || {};
 
-  // Resolve default model from opts or config
-  let floor = opts.default_model || opts.model_floor; // accept both; model_floor is legacy
-  let preference = opts.preference; // legacy compat
-  if (!floor) {
-    try {
-      const config = require('./config');
-      const cfg = config.read();
-      floor = cfg.default_model || cfg.model_floor;
-      if (preference == null) preference = cfg.routing_preference;
-    } catch {}
-  }
-  if (!MODEL_ORDER.includes(floor)) floor = 'sonnet';
-  if (preference == null) preference = 35;
-
-  // Check for user-level force_model override — bypasses all routing logic
-  let forceModel = opts.force_model;
-  if (!forceModel) {
-    try {
-      const config = require('./config');
-      forceModel = config.read().force_model;
-    } catch {}
-  }
-  if (forceModel && MODEL_ORDER.includes(forceModel)) {
-    return {
-      model: forceModel,
-      baseModel: forceModel,
-      default_model: floor,
-      fallbackChain: forceModel === 'haiku' ? ['haiku', 'sonnet', 'opus']
-        : forceModel === 'sonnet' ? ['sonnet', 'opus']
-        : ['opus'],
-      reasons: [`[override] force_model=${forceModel} -- routing bypassed`],
-      costMultiplier: forceModel === 'haiku' ? 1 : forceModel === 'sonnet' ? 3 : 15,
-    };
-  }
-
-  // If a custom rule supplied an explicit model override, honour it directly
+  // Custom rule override — always honored.
   if (customModel && MODEL_ORDER.includes(customModel)) {
     return {
       model: customModel,
-      default_model: floor,
+      baseModel: customModel,
       fallbackChain: customModel === 'haiku' ? ['haiku', 'sonnet', 'opus']
         : customModel === 'sonnet' ? ['sonnet', 'opus']
         : ['opus'],
@@ -515,97 +480,42 @@ function recommendModel(classification, opts = {}) {
     };
   }
 
-  // ── Smart model selection: use user-defined capabilities if models.json exists ──
+  // Baseline — user-defined capabilities first, heuristic fallback.
   let base;
   try {
     const { selectByCapability } = require('./models');
     const smart = selectByCapability(family, complexity);
-    if (smart) {
-      base = { model: smart.model, reason: smart.reason };
-    }
+    if (smart) base = { model: smart.model, reason: smart.reason };
   } catch {}
   if (!base) base = getBaseRecommendation(family, complexity);
 
   let model = base.model;
   const reasons = [base.reason];
 
-  // ── A/B experiment override ──
+  // A/B experiment override — if active, returns immediately.
   try {
     const { getActiveExperiment, assignModel } = require('./experiments');
     const exp = getActiveExperiment(family);
     if (exp) {
       const experimentModel = assignModel(exp);
       if (experimentModel) {
-        model = experimentModel;
         reasons.push(`[experiment] ${exp.id} (${exp.family}) -- assigned ${experimentModel} (${exp.count + 1}/${exp.target})`);
         return {
-          model,
-          default_model: floor,
-          fallbackChain: model === 'haiku' ? ['haiku', 'sonnet', 'opus']
-            : model === 'sonnet' ? ['sonnet', 'opus']
+          model: experimentModel,
+          fallbackChain: experimentModel === 'haiku' ? ['haiku', 'sonnet', 'opus']
+            : experimentModel === 'sonnet' ? ['sonnet', 'opus']
             : ['opus'],
           reasons,
-          costMultiplier: model === 'haiku' ? 1 : model === 'sonnet' ? 3 : 15,
+          costMultiplier: experimentModel === 'haiku' ? 1 : experimentModel === 'sonnet' ? 3 : 15,
           experiment: { id: exp.id, family: exp.family },
         };
       }
     }
   } catch {}
 
-  // ── Apply model floor ──
-  const floorIdx = MODEL_ORDER.indexOf(floor);
-  const modelIdx = MODEL_ORDER.indexOf(model);
-
-  if (floor === 'opus') {
-    // Opus-first: everything runs on opus, no routing
-    if (model !== 'opus') {
-      reasons.push(`floor=opus -- upgraded from ${model}`);
-      model = 'opus';
-    }
-  } else if (floor === 'haiku') {
-    // Haiku-first: start on haiku, only upgrade when task genuinely needs more
-    if (!OPUS_FLOOR.has(family)) {
-      if (model === 'opus' && complexity !== 'high') {
-        model = 'sonnet';
-        reasons.push('floor=haiku -- downgraded opus to sonnet (not high complexity)');
-      }
-      if (model === 'opus' && complexity === 'high' && family === TASK_FAMILIES.DEBUG) {
-        model = 'sonnet';
-        reasons.push('floor=haiku -- trying sonnet for debug first');
-      }
-      if (model === 'sonnet' && complexity === 'low') {
-        model = 'haiku';
-        reasons.push('floor=haiku -- downgraded to haiku (low complexity)');
-      }
-      // Unknown family: we have no reason to pay for sonnet when we can't classify the task
-      if (model === 'sonnet' && family === TASK_FAMILIES.UNKNOWN) {
-        model = 'haiku';
-        reasons.push('floor=haiku -- unclassified task, defaulting to haiku');
-      }
-      // Medium sonnet tasks that are code edits/reviews/plans stay on sonnet — they need it
-      // Everything else at medium goes to haiku
-      const keepSonnet = new Set([TASK_FAMILIES.CODE_EDIT, TASK_FAMILIES.REVIEW, TASK_FAMILIES.PLAN, TASK_FAMILIES.MULTI_FILE, TASK_FAMILIES.DEBUG]);
-      if (model === 'sonnet' && complexity === 'medium' && !keepSonnet.has(family)) {
-        model = 'haiku';
-        reasons.push(`floor=haiku -- ${family} at medium complexity, haiku sufficient`);
-      }
-    }
-  } else {
-    // Sonnet-first (default): downgrade opus for non-high-complexity
-    if (!OPUS_FLOOR.has(family)) {
-      if (model === 'opus' && complexity !== 'high') {
-        model = 'sonnet';
-        reasons.push(`floor=sonnet -- sonnet sufficient for ${complexity} ${family}`);
-      }
-      if (model === 'opus' && complexity === 'high' && family === TASK_FAMILIES.DEBUG) {
-        model = 'sonnet';
-        reasons.push('floor=sonnet -- trying sonnet for debug first');
-      }
-    }
-  }
-
-  // ── Adaptive learning: adjust based on historical success rates ──
-  if (!OPUS_FLOOR.has(family) && floor !== 'opus') {
+  // Adaptive learning nudge — upgrade if historical data shows the baseline underperforms;
+  // surface downgrade opportunities as tips (matrix decides the actual downgrade).
+  if (!OPUS_FLOOR.has(family)) {
     try {
       const { getAdjustment } = require('./learner');
       const adj = getAdjustment(family, model);
@@ -614,15 +524,7 @@ function recommendModel(classification, opts = {}) {
           model = adj.upgradeTo;
           reasons.push(`[learned] ${adj.reason}`);
         } else if (adj.suggestion === 'downgrade' && adj.downgradeTo) {
-          const downgradeIdx = MODEL_ORDER.indexOf(adj.downgradeTo);
-          if (downgradeIdx >= floorIdx) {
-            // Downgrade is within the allowed floor — apply it
-            model = adj.downgradeTo;
-            reasons.push(`[learned] ${adj.reason}`);
-          } else {
-            // Downgrade blocked by model floor — surface as a tip so user can see the insight
-            reasons.push(`[learned:tip] ${adj.reason} (floor=${floor} prevents downgrade to ${adj.downgradeTo})`);
-          }
+          reasons.push(`[learned:tip] ${adj.reason}`);
         } else if (adj.suggestion === 'confirm') {
           reasons.push(`[learned:confirm] ${adj.reason}`);
         }
@@ -633,7 +535,6 @@ function recommendModel(classification, opts = {}) {
   return {
     model,
     baseModel: base.model,
-    default_model: floor,
     fallbackChain: model === 'haiku' ? ['haiku', 'sonnet', 'opus']
       : model === 'sonnet' ? ['sonnet', 'opus']
       : ['opus'],

--- a/src/server.js
+++ b/src/server.js
@@ -503,11 +503,11 @@ const server = http.createServer((req, res) => {
       req.on('end', () => {
         try {
           const updates = JSON.parse(body);
-          // Only allow known config keys
+          // Only allow known config keys. Deprecated keys (default_model, force_model)
+          // are intentionally absent from DEFAULTS since #97, so they'll never match.
           const allowed = new Set(Object.keys(config.DEFAULTS));
           for (const [k, v] of Object.entries(updates)) {
             if (!allowed.has(k)) continue;
-            if (k === 'default_model' && !['haiku', 'sonnet', 'opus'].includes(v)) continue;
             config.set(k, v);
           }
           config.clearCache();
@@ -528,6 +528,7 @@ const server = http.createServer((req, res) => {
     res.end(JSON.stringify({
       matrix: cfg.routing_matrix || config.DEFAULT_MATRIX,
       defaults: config.DEFAULT_MATRIX,
+      presets: config.PRESETS,
       families: config.FAMILIES,
       complexities: config.COMPLEXITIES,
       isUsingDefaults: !cfg.routing_matrix,

--- a/src/validate-log-command.js
+++ b/src/validate-log-command.js
@@ -84,7 +84,7 @@ function runValidateLog(args = []) {
     if (!groundTruth) continue; // skip rows with unrecognized model fields
 
     const classification = router.classifyTask(rec.description);
-    const recommendation = router.recommendModel(classification, floorOverride ? { default_model: floorOverride } : {});
+    const recommendation = router.recommendModel(classification);
     const predicted = recommendation.model;
 
     if (classification.confidence < minConfidence) continue;
@@ -165,10 +165,7 @@ function runValidateLog(args = []) {
   console.log('');
   console.log(`${bold}Token Coach — Validate Log${reset}`);
   console.log(`${gray}${'─'.repeat(44)}${reset}`);
-  const config = require('./config');
-  const activeFloor = floorOverride || config.read().default_model || 'sonnet';
   console.log(`  ${gray}Records:${reset}  ${total}`);
-  console.log(`  ${gray}Floor:${reset}    ${activeFloor}${floorOverride ? '' : ' (from config — use --floor opus to match historical usage)'}`);
   console.log(`  ${gray}Matched:${reset}  ${green}${matched} (${accuracy}%)${reset}`);
   console.log(`  ${gray}Mismatch:${reset} ${red}${mismatched} (${100 - accuracy}%)${reset}`);
   console.log(`  ${gray}Accuracy:${reset} ${accColor}${bold}${accuracy}%${reset}`);

--- a/test/routing-matrix.test.js
+++ b/test/routing-matrix.test.js
@@ -96,11 +96,11 @@ test('updateMatrix merges partial updates without blanking other cells', () => {
 // force_model migration
 // ─────────────────────────────────────────────────────────────
 
-test('force_model seeds every cell on first migrate', () => {
+test('force_model seeds every cell and is dropped from config', () => {
   resetConfig({ force_model: 'haiku' });
   const cfg = config.read();
-  assert.strictEqual(cfg.force_model, null, 'force_model should be cleared after migration');
-  assert.strictEqual(cfg._force_model_migrated, 'haiku', 'migration marker should record the forced value');
+  assert.strictEqual(cfg.force_model, undefined, 'force_model key is removed after migration');
+  assert.strictEqual(cfg._force_model_migrated, 'haiku', 'migration marker records the forced value');
   for (const f of config.FAMILIES) {
     for (const cx of config.COMPLEXITIES) {
       assert.strictEqual(config.getMatrixCell(f, cx), 'haiku', `${f}/${cx} should be seeded to haiku`);
@@ -114,8 +114,15 @@ test('force_model migration does not overwrite existing matrix', () => {
     routing_matrix: { code_edit: { low: 'haiku', medium: 'haiku', high: 'haiku' } },
   });
   const cfg = config.read();
-  assert.strictEqual(cfg.force_model, 'opus', 'force_model should NOT be touched when matrix already exists');
-  assert.strictEqual(config.getMatrixCell('code_edit', 'low'), 'haiku');
+  assert.strictEqual(cfg.force_model, undefined, 'force_model key is always removed after read');
+  assert.strictEqual(config.getMatrixCell('code_edit', 'low'), 'haiku', 'existing matrix wins');
+});
+
+test('deprecated keys (default_model, model_floor) are silently dropped', () => {
+  resetConfig({ default_model: 'haiku', model_floor: 'opus', routing_matrix: null });
+  const cfg = config.read();
+  assert.strictEqual(cfg.default_model, undefined);
+  assert.strictEqual(cfg.model_floor, undefined);
 });
 
 // ─────────────────────────────────────────────────────────────
@@ -145,6 +152,40 @@ test('suggestMatrix skips families with insufficient samples', () => {
   seedOutcomes('plan', 'haiku', 5, 1.0);
   const m = suggestMatrix(config.DEFAULT_MATRIX);
   assert.strictEqual(m.plan.medium, config.DEFAULT_MATRIX.plan.medium);
+});
+
+// ─────────────────────────────────────────────────────────────
+// Presets (#97)
+// ─────────────────────────────────────────────────────────────
+
+test('PRESETS contains all five named presets', () => {
+  const names = Object.keys(config.PRESETS).sort();
+  assert.deepStrictEqual(names, ['Balanced', 'Budget', 'Coder', 'Max accuracy', 'Reader']);
+});
+
+test('each preset has every family × complexity cell populated', () => {
+  const validModels = new Set(['haiku', 'sonnet', 'opus']);
+  for (const [name, matrix] of Object.entries(config.PRESETS)) {
+    for (const f of config.FAMILIES) {
+      assert.ok(matrix[f], `preset "${name}" missing family ${f}`);
+      for (const cx of config.COMPLEXITIES) {
+        assert.ok(validModels.has(matrix[f][cx]), `preset "${name}" has invalid value at ${f}/${cx}: ${matrix[f][cx]}`);
+      }
+    }
+  }
+});
+
+test('Balanced preset equals DEFAULT_MATRIX', () => {
+  assert.deepStrictEqual(config.PRESETS.Balanced, config.DEFAULT_MATRIX);
+});
+
+test('Max accuracy preset is all opus', () => {
+  const matrix = config.PRESETS['Max accuracy'];
+  for (const f of config.FAMILIES) {
+    for (const cx of config.COMPLEXITIES) {
+      assert.strictEqual(matrix[f][cx], 'opus');
+    }
+  }
 });
 
 const passed = results.filter(r => r.ok).length;


### PR DESCRIPTION
Closes #97. **Stacked on #96** (target base: \`feature/95-routing-matrix\`). Once #96 merges to main, I'll retarget this PR or it'll auto-update.

## What this does

With the routing matrix (#95) landed, both \`default_model\` and \`force_model\` are redundant and confusing. Remove them. Add a "Preset" dropdown so new users have a one-click on-ramp instead of staring at 30 blank cells.

## Net removed: 158 lines

12 files changed, 177 insertions(+), 335 deletions(-).

## Presets shipped

| Preset | Behavior |
|---|---|
| Balanced | DEFAULT_MATRIX — safe defaults |
| Coder | opus-heavy for code_edit / multi_file / debug / architecture |
| Reader | haiku-heavy for search / review / question / command |
| Budget | haiku everywhere possible; sonnet for mid-tier debug/architecture |
| Max accuracy | opus in every cell (equivalent to old force_model=opus) |

## Key changes

- \`src/config.js\` — drop \`default_model\` / \`force_model\` keys; silent-delete on read; add \`PRESETS\` export
- \`src/router.js\` — \`recommendModel()\` takes no opts; removed 100+ lines of floor/preference/force logic
- \`bin/hook-router.js\` — removed override detection, banner line, \`[override]\` reason tag
- \`src/server.js\` — \`/api/matrix\` GET exposes \`presets\`
- \`public/index.html\` — "Default model" card → "Settings" card (history + feedback only); matrix card gains "Preset:" dropdown; removed 70 lines of floor/override UI
- \`bin/cli.js\` — \`config default_model ...\` now errors with "use the dashboard matrix" pointer

## Migration behavior

- Users with \`force_model\` set still get the #95 auto-migration → matrix seeded, \`_force_model_migrated\` marker set for UI banner
- \`default_model\` silently dropped — matrix's own defaults apply
- Old configs don't error on load

## Tests: 15/15

Added 4 preset tests (shape, completeness, Balanced equality, Max accuracy correctness).

## Manual test plan

- [ ] Open dashboard, "Default model" card is gone; "Settings" card only has history retention + feedback loop
- [ ] Matrix card has new "Preset:" dropdown with 5 options
- [ ] Selecting "Coder" populates grid with opus-heavy values; Save persists
- [ ] Selecting "Max accuracy" sets every cell to opus
- [ ] \`claude-tokens config default_model haiku\` errors with pointer to dashboard
- [ ] User with pre-existing \`force_model\` in config sees migration banner + all-seeded cells
- [ ] User with pre-existing \`default_model\` sees it silently dropped; no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)